### PR TITLE
ci: Add ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  calculate-policy-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      policy-working-dirs: ${{ steps.calculate-policy-dirs.outputs.policy_working_dirs }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # checkout all history to do git diff
+      - id: calculate-policy-dirs
+        shell: bash
+        run: |
+          # policy_working_dirs must be a string on the form of '[ "policies/Foo", "policies/Bar" ]' or '[]'
+           
+          # list only changes of files in `policies/`:
+          pushd policies
+          git_files="$(git diff --no-color --find-renames --find-copies --name-only origin/main ${{ github.sha }} -- .)"
+
+          # build policy_working_dirs:
+          dir_bash_array=($(echo "$git_files" | cut -d/ -f1,2 ))
+          declare -p dir_bash_array # for debug
+          policy_working_dirs=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${dir_bash_array[@]}")
+          echo "policy_working_dirs=$policy_working_dirs" >> $GITHUB_OUTPUT
+
+  continuous-integration:
+    if: ${{ needs.calculate-policy-matrix.outputs.policy-working-dirs != '[]' }}
+    needs: calculate-policy-matrix
+    strategy:
+      matrix:
+        policy-working-dir: ${{ fromJSON(needs.calculate-policy-matrix.outputs.policy-working-dirs) }}
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rego.yml@v3.4.0
+    with:
+      policy-working-dir: ${{ matrix.policy-working-dir }}
+      # hardcode a bogus but semver valid version for `make check-artifacthub.yml`.
+      # This is needed because there's no easy way inside of
+      # reusable-test-policy-rego to differentiate between a monorepo (with
+      # tags like `PolicyFoo/v0.1.0`) and a normal repo (with tags like
+      # `v0.1.0`), and check-artifacthub uses `git describe tags` to create a
+      # bogus but semver valid version.
+      policy-version: 0.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # checkout all history to do git diff
-      - id: calculate-policy-dirs
+      - name: calculate which policies need a CI job
+        id: calculate-policy-dirs
         shell: bash
         run: |
           # policy_working_dirs must be a string on the form of '[ "policies/Foo", "policies/Bar" ]' or '[]'

--- a/README
+++ b/README
@@ -1,0 +1,24 @@
+# Rego policies library
+
+This repository contains a collection of Rego policies that can be used with
+Kubewarden to enforce security and compliance best practices.
+
+These policies have been adapted from https://github.com/weaveworks/policy-library.
+
+Weaveworks has been a pioneer in the field of Kubernetes security and
+compliance. They transitioned to a community-driven project with the closure of
+their start-up company at the beginning of 2024, which was a sad moment in the
+cloud native sphere. We thank Weaveworks and their contributors for their work
+on these policies, and we believe they are a good asset for Kubernetes users.
+
+The policies are organized as:
+- `policies/`: Production ready, tested policies, released via tags to
+  `ghcr.io/kubewarden/policies` and artifacthub.io.
+- `staging/`: Policies under evaluation, not yet released.
+
+## Releasing a policy
+
+Push a new tag with the pattern `PolicyName/vX.Y.Z`, with the policy in the
+folder `policies/PolicyName`. The release job will test, build and push the
+policy to `ghcr.io/kubewarden/policies`, create the corresponding GH release,
+as well as updating the `artifacthub` branch in this repository.


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Part of  https://github.com/kubewarden/kubewarden-controller/issues/806.

Add ci.yml workflow for PRs, that starts 1 job per policy to be tested, if there's any change inside the policy folder.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
This was tested in my viccuad/rego-policies repo.

To see how it looks on a PR:
https://github.com/viccuad/rego-policies/pull/4
Note how there's 2 jobs per policy scheduled, some of them fail, some succeed, all of that expected.

To see how it looks on main:
https://github.com/viccuad/rego-policies/actions/runs/12374488427
Note that the calculate-policy-dirs creates a strategy matrix that is correctly empty, so no follow-up jobs are scheduled.
<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
