### PR TITLE
ci: add artifacthub-repo.yml

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,5 @@
+---
+repositoryID: bc417a86-98d2-45b8-98dc-824223c78d6f
+owners:
+  - name: Kubewarden developers
+    email: kubewarden@suse.de


### PR DESCRIPTION
## Description

Adds missing `artifacthub-repo.yml` to the main branch.
This was causing release action failures, see https://github.com/kubewarden/rego-policies-library/actions/runs/13629300223/job/38093486848#step:2:229



