### PR TITLE
ci: fix release job concurrency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,6 @@ jobs:
       packages: write
       # Required by cosign keyless signing
       id-token: write
-    concurrency:
-      group: release-policy # only allow 1 release job of "release-policy" concurrently
-      cancel-in-progress: false
     uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rego.yml@v3.4.6
     with:
       oci-target: ghcr.io/${{ github.repository_owner }}/policies/${{ needs.calculate-policy-from-tag.outputs.policy-id }}


### PR DESCRIPTION
## Description
This PR removes the concurrency limit on the release job as it is unlikely that we will release two tags of the same policy concurrently.
Also, the concurrency limit here is wrong as it limits the global concurrency of the release job.