### PR TITLE
fix: artifacthub pkg release links

### DIFF
--- a/policies/ControllerAffinityNodeSelector/Makefile
+++ b/policies/ControllerAffinityNodeSelector/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerAffinityNodeSelector/artifacthub-pkg.yml
+++ b/policies/ControllerAffinityNodeSelector/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: affinity-node-selector
 displayName: Affinity Node Selector
-createdAt: 2025-03-03T13:09:33.306129596Z
+createdAt: 2025-03-04T11:58:02.828294325Z
 description: "This Policy allows setting a key and value for `nodeSelector` when assigning pods to nodes. \n\n`nodeSelector` is a field of PodSpec. It specifies a map of key-value pairs. For the pod to be eligible to scheduled on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/affinity-node-selector:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerAffinityNodeSelector%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerContainerBlockSSHPort/Makefile
+++ b/policies/ControllerContainerBlockSSHPort/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerContainerBlockSSHPort/artifacthub-pkg.yml
+++ b/policies/ControllerContainerBlockSSHPort/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: containers-block-ssh-port
 displayName: Containers Block Ssh Port
-createdAt: 2025-03-03T13:00:40.705636709Z
+createdAt: 2025-03-04T11:58:02.886534739Z
 description: |
   This Policy checks if the container is exposing ssh port.
 license: Apache-2.0
@@ -19,7 +19,7 @@ keywords:
 - pci-dss
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerContainerBlockSSHPort%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerContainerBlockSysctls/Makefile
+++ b/policies/ControllerContainerBlockSysctls/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerContainerBlockSysctls/artifacthub-pkg.yml
+++ b/policies/ControllerContainerBlockSysctls/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: container-block-sysctl
 displayName: Container Block Sysctls
-createdAt: 2025-03-03T13:09:33.460136641Z
+createdAt: 2025-03-04T11:58:02.938973802Z
 description: "Setting sysctls can allow containers unauthorized escalated privileges to a Kubernetes node. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -23,7 +23,7 @@ keywords:
 - default
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerContainerBlockSysctls%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerContainerBlockSysctls_CVE-2022-0811/Makefile
+++ b/policies/ControllerContainerBlockSysctls_CVE-2022-0811/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerContainerBlockSysctls_CVE-2022-0811/artifacthub-pkg.yml
+++ b/policies/ControllerContainerBlockSysctls_CVE-2022-0811/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: container-block-sysctl.cve-2022-0811
 displayName: Container Block Sysctls CVE-2022-0811
-createdAt: 2025-03-03T13:09:33.531677233Z
+createdAt: 2025-03-04T11:58:02.991031415Z
 description: "Setting sysctls can allow containers unauthorized escalated privileges to a Kubernetes node. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -23,7 +23,7 @@ keywords:
 - default
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerContainerBlockSysctls_CVE-2022-0811%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerContainerRunningAsRoot/Makefile
+++ b/policies/ControllerContainerRunningAsRoot/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerContainerRunningAsRoot/artifacthub-pkg.yml
+++ b/policies/ControllerContainerRunningAsRoot/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: container-running-as-root
 displayName: Container Running As Root
-createdAt: 2025-03-03T13:09:33.609991826Z
+createdAt: 2025-03-04T11:58:03.043225489Z
 description: "Running as root gives the container full access to all resources in the VM it is running on. Containers should not run with such access rights unless required by design. This Policy enforces that the `securityContext.runAsNonRoot` attribute is set to `true`. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -23,7 +23,7 @@ keywords:
 - default
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerContainerRunningAsRoot%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerContainerRunningAsUser/Makefile
+++ b/policies/ControllerContainerRunningAsUser/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerContainerRunningAsUser/artifacthub-pkg.yml
+++ b/policies/ControllerContainerRunningAsUser/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: container-running-as-user
 displayName: Container Running As User
-createdAt: 2025-03-03T13:09:33.682328318Z
+createdAt: 2025-03-04T11:58:03.096366663Z
 description: "Containers has a feature in which you specify the ID of the user which all processes in the container will run with. This Policy enforces that the `securityContext.runAsUser` attribute is set to a uid greater than root uid. Running as root user gives the container full access to all resources in the VM it is running on. Containers should not run with such access rights unless required by design. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -23,7 +23,7 @@ keywords:
 - default
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerContainerRunningAsUser%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerImageName/Makefile
+++ b/policies/ControllerImageName/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerImageName/artifacthub-pkg.yml
+++ b/policies/ControllerImageName/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: containers-block-specific-image-names
 displayName: Containers Block Specific Image Names
-createdAt: 2025-03-03T13:09:33.747547695Z
+createdAt: 2025-03-04T11:58:03.149230365Z
 description: "This Policy prohibits images with certain image names from being deployed by specifying a list of unapproved names. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/containers-block-specific-image-names:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerImageName%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerMissingKubernetesAppComponentLabel/Makefile
+++ b/policies/ControllerMissingKubernetesAppComponentLabel/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerMissingKubernetesAppComponentLabel/artifacthub-pkg.yml
+++ b/policies/ControllerMissingKubernetesAppComponentLabel/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: missing-kubernetes-app-component-label
 displayName: Missing Kubernetes App Component Label
-createdAt: 2025-03-03T13:09:33.814241893Z
+createdAt: 2025-03-04T11:58:03.20260951Z
 description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\t\n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/missing-kubernetes-app-component-label:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerMissingKubernetesAppComponentLabel%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerMissingKubernetesAppCreatedByLabel/Makefile
+++ b/policies/ControllerMissingKubernetesAppCreatedByLabel/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerMissingKubernetesAppCreatedByLabel/artifacthub-pkg.yml
+++ b/policies/ControllerMissingKubernetesAppCreatedByLabel/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: missing-kubernetes-app-created-by-label
 displayName: Missing Kubernetes App Created By Label
-createdAt: 2025-03-03T13:09:33.881006917Z
+createdAt: 2025-03-04T11:58:03.256143743Z
 description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\t\n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/missing-kubernetes-app-created-by-label:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerMissingKubernetesAppCreatedByLabel%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerMissingKubernetesAppInstanceLabel/Makefile
+++ b/policies/ControllerMissingKubernetesAppInstanceLabel/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerMissingKubernetesAppInstanceLabel/artifacthub-pkg.yml
+++ b/policies/ControllerMissingKubernetesAppInstanceLabel/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: missing-kubernetes-app-instance-label
 displayName: Missing Kubernetes App Instance Label
-createdAt: 2025-03-03T13:09:33.947288608Z
+createdAt: 2025-03-04T11:58:03.308899061Z
 description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/missing-kubernetes-app-instance-label:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerMissingKubernetesAppInstanceLabel%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerMissingKubernetesAppLabel/Makefile
+++ b/policies/ControllerMissingKubernetesAppLabel/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerMissingKubernetesAppLabel/artifacthub-pkg.yml
+++ b/policies/ControllerMissingKubernetesAppLabel/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: missing-kubernetes-app-label
 displayName: Missing Kubernetes App Label
-createdAt: 2025-03-03T13:09:34.011880056Z
+createdAt: 2025-03-04T11:58:03.36133708Z
 description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/missing-kubernetes-app-label:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerMissingKubernetesAppLabel%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerMissingKubernetesAppManagedByLabel/Makefile
+++ b/policies/ControllerMissingKubernetesAppManagedByLabel/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerMissingKubernetesAppManagedByLabel/artifacthub-pkg.yml
+++ b/policies/ControllerMissingKubernetesAppManagedByLabel/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: missing-kubernetes-app-managed-by-label
 displayName: Missing Kubernetes App Managed By Label
-createdAt: 2025-03-03T13:09:34.078571469Z
+createdAt: 2025-03-04T11:58:03.413273905Z
 description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\t\n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/missing-kubernetes-app-managed-by-label:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerMissingKubernetesAppManagedByLabel%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerMissingKubernetesAppPartOfLabel/Makefile
+++ b/policies/ControllerMissingKubernetesAppPartOfLabel/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerMissingKubernetesAppPartOfLabel/artifacthub-pkg.yml
+++ b/policies/ControllerMissingKubernetesAppPartOfLabel/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: missing-kubernetes-app-part-of-label
 displayName: Missing Kubernetes App Part Of Label
-createdAt: 2025-03-03T13:09:34.145947843Z
+createdAt: 2025-03-04T11:58:03.463197483Z
 description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\t\n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/missing-kubernetes-app-part-of-label:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerMissingKubernetesAppPartOfLabel%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerMissingKubernetesAppVersionLabel/Makefile
+++ b/policies/ControllerMissingKubernetesAppVersionLabel/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerMissingKubernetesAppVersionLabel/artifacthub-pkg.yml
+++ b/policies/ControllerMissingKubernetesAppVersionLabel/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: missing-kubernetes-app-version-label
 displayName: Missing Kubernetes App Version Label
-createdAt: 2025-03-03T13:09:34.215025056Z
+createdAt: 2025-03-04T11:58:03.515489547Z
 description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\t\n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/missing-kubernetes-app-version-label:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerMissingKubernetesAppVersionLabel%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerMissingLabelValue/Makefile
+++ b/policies/ControllerMissingLabelValue/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerMissingLabelValue/artifacthub-pkg.yml
+++ b/policies/ControllerMissingLabelValue/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: metadata-missing-label-and-value
 displayName: Metadata Missing Label And Value
-createdAt: 2025-03-03T13:09:34.278338787Z
+createdAt: 2025-03-04T11:58:03.568848597Z
 description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensures a key and value are set in the entity's `metadata.labels` path. The Policy detects the presence of the following: \n\n### label\nA label key of your choosing. \n\n### value\nA label value of your choosing.\n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/metadata-missing-label-and-value:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerMissingLabelValue%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerMissingNamespace/Makefile
+++ b/policies/ControllerMissingNamespace/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerMissingNamespace/artifacthub-pkg.yml
+++ b/policies/ControllerMissingNamespace/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: block-workloads-created-without-specifying-namespace
 displayName: Block Workloads Created Without Specifying Namespace
-createdAt: 2025-03-03T13:09:34.34640528Z
+createdAt: 2025-03-04T11:58:03.620911214Z
 description: "Using this Policy, you can prohibit workloads from being created in a default namespace due to the lack of a namespace label. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/block-workloads-created-without-specifying-namespace:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerMissingNamespace%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerMissingOwnerLabel/Makefile
+++ b/policies/ControllerMissingOwnerLabel/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerMissingOwnerLabel/artifacthub-pkg.yml
+++ b/policies/ControllerMissingOwnerLabel/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: missing-owner-label
 displayName: Missing Owner Label
-createdAt: 2025-03-03T13:09:34.415601261Z
+createdAt: 2025-03-04T11:58:03.673522614Z
 description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\t\n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/missing-owner-label:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerMissingOwnerLabel%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerMissingSecurityContext/Makefile
+++ b/policies/ControllerMissingSecurityContext/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerMissingSecurityContext/artifacthub-pkg.yml
+++ b/policies/ControllerMissingSecurityContext/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: containers-missing-security-context
 displayName: Containers Missing Security Context
-createdAt: 2025-03-03T13:09:34.48122843Z
+createdAt: 2025-03-04T11:58:03.725518487Z
 description: |
   This Policy checks if the container is missing securityContext while there is no securityContext defined on the Pod level as well. The security settings that are specified on the Pod level apply to all containers in the Pod.
 license: Apache-2.0
@@ -24,7 +24,7 @@ keywords:
 - default
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerMissingSecurityContext%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/ControllerProhibitNamespace/Makefile
+++ b/policies/ControllerProhibitNamespace/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/ControllerProhibitNamespace/artifacthub-pkg.yml
+++ b/policies/ControllerProhibitNamespace/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: containers-should-not-run-in-namespace
 displayName: Containers Should Not Run In Namespace
-createdAt: 2025-03-03T13:09:34.550299035Z
+createdAt: 2025-03-04T11:58:03.7757883Z
 description: "This Policy ensure workloads are not running in a specified namespace. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -19,7 +19,7 @@ keywords:
 - soc2-type1
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/ControllerProhibitNamespace%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxBucketApprovedRegion/Makefile
+++ b/policies/FluxBucketApprovedRegion/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxBucketApprovedRegion/artifacthub-pkg.yml
+++ b/policies/FluxBucketApprovedRegion/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: bucket-approved-region
 displayName: Bucket Approved Region
-createdAt: 2025-03-03T13:09:34.620424906Z
+createdAt: 2025-03-04T11:58:03.826940837Z
 description: Bucket region must be one of the approved regions.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxBucketApprovedRegion%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxBucketEndpointDomain/Makefile
+++ b/policies/FluxBucketEndpointDomain/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxBucketEndpointDomain/artifacthub-pkg.yml
+++ b/policies/FluxBucketEndpointDomain/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: bucket-endpoint-domain
 displayName: Bucket Endpoint Domain
-createdAt: 2025-03-03T13:09:34.68542396Z
+createdAt: 2025-03-04T11:58:03.87898169Z
 description: Bucket endpoint domain must be one of the trusted domains.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxBucketEndpointDomain%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxBucketInsecure/Makefile
+++ b/policies/FluxBucketInsecure/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxBucketInsecure/artifacthub-pkg.yml
+++ b/policies/FluxBucketInsecure/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: bucket-insecure-connections
 displayName: Bucket Insecure Connections
-createdAt: 2025-03-03T13:09:34.749829633Z
+createdAt: 2025-03-04T11:58:03.931197469Z
 description: Ensure that Bucket objects do not use insecure connections
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxBucketInsecure%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxGitRepositoryIgonreSuffixes/Makefile
+++ b/policies/FluxGitRepositoryIgonreSuffixes/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxGitRepositoryIgonreSuffixes/artifacthub-pkg.yml
+++ b/policies/FluxGitRepositoryIgonreSuffixes/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: gitrepository-ignore-suffixes
 displayName: GitRepository Ignore Suffixes
-createdAt: 2025-03-03T13:09:34.816224776Z
+createdAt: 2025-03-04T11:58:03.983052442Z
 description: GitRepository resources must include specific suffixes in the spec.ignore field which determines the files to be ignored before making a commit.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxGitRepositoryIgonreSuffixes%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxGitRepositoryOrganizationDomains/Makefile
+++ b/policies/FluxGitRepositoryOrganizationDomains/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxGitRepositoryOrganizationDomains/artifacthub-pkg.yml
+++ b/policies/FluxGitRepositoryOrganizationDomains/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: gitrepository-organization-domains
 displayName: GitRepository Organization Domains
-createdAt: 2025-03-03T13:09:34.881909455Z
+createdAt: 2025-03-04T11:58:04.037849633Z
 description: GitRepository resources must only be from allowed organization domains.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxGitRepositoryOrganizationDomains%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxGitRepositorySpecificBranch/Makefile
+++ b/policies/FluxGitRepositorySpecificBranch/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxGitRepositorySpecificBranch/artifacthub-pkg.yml
+++ b/policies/FluxGitRepositorySpecificBranch/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: gitrepository-specific-branch
 displayName: GitRepository Specific Branch
-createdAt: 2025-03-03T13:09:34.949069742Z
+createdAt: 2025-03-04T11:58:04.092444864Z
 description: GitRepository resources must reference a specific branch, e.g. 'main'.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxGitRepositorySpecificBranch%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxGitRepositoryUntrustedDomains/Makefile
+++ b/policies/FluxGitRepositoryUntrustedDomains/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxGitRepositoryUntrustedDomains/artifacthub-pkg.yml
+++ b/policies/FluxGitRepositoryUntrustedDomains/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: gitrepository-untrusted-domains
 displayName: GitRepository Untrusted Domains
-createdAt: 2025-03-03T13:09:35.020938922Z
+createdAt: 2025-03-04T11:58:04.145529451Z
 description: GitRepository resources must not use targets from untrusted domains.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxGitRepositoryUntrustedDomains%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmChartCosignVerification/Makefile
+++ b/policies/FluxHelmChartCosignVerification/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmChartCosignVerification/artifacthub-pkg.yml
+++ b/policies/FluxHelmChartCosignVerification/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-chart-cosign-verification
 displayName: HelmChart Cosign Verification
-createdAt: 2025-03-03T13:09:35.086858563Z
+createdAt: 2025-03-04T11:58:04.196379708Z
 description: HelmChart objects must provide cosign verification and reference a secret containing the Cosign public keys of trusted authors
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmChartCosignVerification%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmChartValuesFormat/Makefile
+++ b/policies/FluxHelmChartValuesFormat/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmChartValuesFormat/artifacthub-pkg.yml
+++ b/policies/FluxHelmChartValuesFormat/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-chart-values-files-format
 displayName: HelmChart Values File Format
-createdAt: 2025-03-03T13:09:35.151388983Z
+createdAt: 2025-03-04T11:58:04.248365252Z
 description: 'HelmChart must reference values files in the following format: ''xxx=values.yaml''.'
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmChartValuesFormat%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmReleaseMaxHistory/Makefile
+++ b/policies/FluxHelmReleaseMaxHistory/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmReleaseMaxHistory/artifacthub-pkg.yml
+++ b/policies/FluxHelmReleaseMaxHistory/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-release-max-history
 displayName: Helm Release Max History
-createdAt: 2025-03-03T13:09:35.216354345Z
+createdAt: 2025-03-04T11:58:04.299325011Z
 description: HelmRelease maxHistory cannot exceed the specified value.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmReleaseMaxHistory%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmReleaseNameSpaceMatch/Makefile
+++ b/policies/FluxHelmReleaseNameSpaceMatch/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmReleaseNameSpaceMatch/artifacthub-pkg.yml
+++ b/policies/FluxHelmReleaseNameSpaceMatch/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-release-namespace-match
 displayName: Helm Release Namespace Match
-createdAt: 2025-03-03T13:09:35.283313771Z
+createdAt: 2025-03-04T11:58:04.350227599Z
 description: HelmRelease storageNamespace and targetNamespace must match.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmReleaseNameSpaceMatch%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmReleasePostRenderer/Makefile
+++ b/policies/FluxHelmReleasePostRenderer/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmReleasePostRenderer/artifacthub-pkg.yml
+++ b/policies/FluxHelmReleasePostRenderer/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-release-post-renderer
 displayName: Helm Release Post Renderer
-createdAt: 2025-03-03T13:09:35.350039717Z
+createdAt: 2025-03-04T11:58:04.401833891Z
 description: HelmRelease must not have post-renderers enabled.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmReleasePostRenderer%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmReleaseRemediationRetries/Makefile
+++ b/policies/FluxHelmReleaseRemediationRetries/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmReleaseRemediationRetries/artifacthub-pkg.yml
+++ b/policies/FluxHelmReleaseRemediationRetries/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-release-remediation-retries
 displayName: Helm Release Remediation Retries
-createdAt: 2025-03-03T13:09:35.416867536Z
+createdAt: 2025-03-04T11:58:04.454193117Z
 description: HelmRelease remediation retries must be within the specified lower and upper bounds.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmReleaseRemediationRetries%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmReleaseRollback/Makefile
+++ b/policies/FluxHelmReleaseRollback/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmReleaseRollback/artifacthub-pkg.yml
+++ b/policies/FluxHelmReleaseRollback/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-release-rollback
 displayName: Helm Release Rollback Should Be Disabled
-createdAt: 2025-03-03T13:09:35.484675167Z
+createdAt: 2025-03-04T11:58:04.505807334Z
 description: The rollback feature of a HelmRelease should be disabled.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmReleaseRollback%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmReleaseServiceAccountName/Makefile
+++ b/policies/FluxHelmReleaseServiceAccountName/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmReleaseServiceAccountName/artifacthub-pkg.yml
+++ b/policies/FluxHelmReleaseServiceAccountName/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-release-service-account-name
 displayName: Helm Release Service Account Name
-createdAt: 2025-03-03T13:09:35.553767691Z
+createdAt: 2025-03-04T11:58:04.557407302Z
 description: HelmRelease serviceAccountName must contain a value from parameters.service_account_names
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmReleaseServiceAccountName%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmReleaseStorageNamespace/Makefile
+++ b/policies/FluxHelmReleaseStorageNamespace/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmReleaseStorageNamespace/artifacthub-pkg.yml
+++ b/policies/FluxHelmReleaseStorageNamespace/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-release-storage-namespace
 displayName: Helm Release Storage Namespace
-createdAt: 2025-03-03T13:09:35.620817023Z
+createdAt: 2025-03-04T11:58:04.609011686Z
 description: HelmRelease storageNamespace must contain a value from storage_namespaces.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmReleaseStorageNamespace%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmReleaseTargetNameSpace/Makefile
+++ b/policies/FluxHelmReleaseTargetNameSpace/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmReleaseTargetNameSpace/artifacthub-pkg.yml
+++ b/policies/FluxHelmReleaseTargetNameSpace/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-release-target-namespace
 displayName: Helm Release Target Namespace
-createdAt: 2025-03-03T13:09:35.684583767Z
+createdAt: 2025-03-04T11:58:04.659883657Z
 description: HelmRelease targetNamespace must be one of the allowed targetNamespace list.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmReleaseTargetNameSpace%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmReleaseValuesFromConfigMaps/Makefile
+++ b/policies/FluxHelmReleaseValuesFromConfigMaps/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmReleaseValuesFromConfigMaps/artifacthub-pkg.yml
+++ b/policies/FluxHelmReleaseValuesFromConfigMaps/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-release-values-from-configmaps
 displayName: Helm Release Values From
-createdAt: 2025-03-03T13:09:35.749843648Z
+createdAt: 2025-03-04T11:58:04.711730145Z
 description: HelmRelease valuesFrom must use correctly configured ConfigMaps.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmReleaseValuesFromConfigMaps%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmRepositoryType/Makefile
+++ b/policies/FluxHelmRepositoryType/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmRepositoryType/artifacthub-pkg.yml
+++ b/policies/FluxHelmRepositoryType/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-repo-type
 displayName: Helm Repo Type Should Be OCI
-createdAt: 2025-03-03T13:09:35.816479889Z
+createdAt: 2025-03-04T11:58:04.763392886Z
 description: The type of a Helm repository should be OCI.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmRepositoryType%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxHelmRepositoryURL/Makefile
+++ b/policies/FluxHelmRepositoryURL/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxHelmRepositoryURL/artifacthub-pkg.yml
+++ b/policies/FluxHelmRepositoryURL/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: helm-repo-url
 displayName: Helm Repo URL Should Be in Organisation Domain
-createdAt: 2025-03-03T13:09:35.883291864Z
+createdAt: 2025-03-04T11:58:04.814708878Z
 description: The URL of a Helm repository should only be from the specified organisation domain.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxHelmRepositoryURL%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxKustomizationDecryptionProvider/Makefile
+++ b/policies/FluxKustomizationDecryptionProvider/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxKustomizationDecryptionProvider/artifacthub-pkg.yml
+++ b/policies/FluxKustomizationDecryptionProvider/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: kustomization-decryption-provider
 displayName: Kustomization Decryption Provider
-createdAt: 2025-03-03T13:09:35.959240562Z
+createdAt: 2025-03-04T11:58:04.867218869Z
 description: Spec.decryption.provider must be set to one of decryption_providers.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxKustomizationDecryptionProvider%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxKustomizationImageTagStandards/Makefile
+++ b/policies/FluxKustomizationImageTagStandards/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxKustomizationImageTagStandards/artifacthub-pkg.yml
+++ b/policies/FluxKustomizationImageTagStandards/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: kustomization-image-tag-standards
 displayName: Kustomization Image Tag Standards
-createdAt: 2025-03-03T13:09:36.021841856Z
+createdAt: 2025-03-04T11:58:04.918373168Z
 description: spec.Images must comply with image tag/semver reference standards.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxKustomizationImageTagStandards%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxKustomizationPaths/Makefile
+++ b/policies/FluxKustomizationPaths/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxKustomizationPaths/artifacthub-pkg.yml
+++ b/policies/FluxKustomizationPaths/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: kustomization-excluded-paths
 displayName: Kustomization Excluded Paths
-createdAt: 2025-03-03T13:09:36.086538363Z
+createdAt: 2025-03-04T11:58:04.970887174Z
 description: spec.path cannot be one of excludedPathsList[]
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxKustomizationPaths%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxKustomizationTargetNamespace/Makefile
+++ b/policies/FluxKustomizationTargetNamespace/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxKustomizationTargetNamespace/artifacthub-pkg.yml
+++ b/policies/FluxKustomizationTargetNamespace/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: kustomization-target-namespace
 displayName: Kustomization Target Namespace
-createdAt: 2025-03-03T13:09:36.150247115Z
+createdAt: 2025-03-04T11:58:05.02321646Z
 description: Kustomization targetNamespace must be one of the allowed targetNamespace list.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxKustomizationTargetNamespace%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxKustomizationVarSubstitution/Makefile
+++ b/policies/FluxKustomizationVarSubstitution/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxKustomizationVarSubstitution/artifacthub-pkg.yml
+++ b/policies/FluxKustomizationVarSubstitution/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: kustomization-var-substitution
 displayName: Kustomization Var Substitution
-createdAt: 2025-03-03T13:09:36.217789004Z
+createdAt: 2025-03-04T11:58:05.075208048Z
 description: The property 'spec.postBuild.substitute.var_substitution_enabled' must be disabled.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxKustomizationVarSubstitution%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxKustomizeImagesRequirement/Makefile
+++ b/policies/FluxKustomizeImagesRequirement/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxKustomizeImagesRequirement/artifacthub-pkg.yml
+++ b/policies/FluxKustomizeImagesRequirement/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: kustomization-images-requirement
 displayName: Kustomization Images Requirement
-createdAt: 2025-03-03T13:09:36.285316593Z
+createdAt: 2025-03-04T11:58:05.128705415Z
 description: The 'spec.images' field in a Kustomization object must be enabled or disabled based on the policy input images_required.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxKustomizeImagesRequirement%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxKustomizePatchesRequirement/Makefile
+++ b/policies/FluxKustomizePatchesRequirement/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxKustomizePatchesRequirement/artifacthub-pkg.yml
+++ b/policies/FluxKustomizePatchesRequirement/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: kustomization-patches-requirement
 displayName: Kustomization Patches
-createdAt: 2025-03-03T13:09:36.350696269Z
+createdAt: 2025-03-04T11:58:05.180992715Z
 description: Kustomization patches should be enabled or disabled based on input.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxKustomizePatchesRequirement%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxKustomizePrune/Makefile
+++ b/policies/FluxKustomizePrune/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxKustomizePrune/artifacthub-pkg.yml
+++ b/policies/FluxKustomizePrune/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: kustomization-prune
 displayName: Kustomization Prune
-createdAt: 2025-03-03T13:09:36.420100396Z
+createdAt: 2025-03-04T11:58:05.232301847Z
 description: The 'spec.prune' field in the Kustomization object must be set according to the input parameter 'prune'.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxKustomizePrune%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxOCIRepositoryCosignVerification/Makefile
+++ b/policies/FluxOCIRepositoryCosignVerification/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxOCIRepositoryCosignVerification/artifacthub-pkg.yml
+++ b/policies/FluxOCIRepositoryCosignVerification/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: ocirepository-cosign-verification
 displayName: OCIRepository Cosign Verification
-createdAt: 2025-03-03T13:09:36.483923204Z
+createdAt: 2025-03-04T11:58:05.283998517Z
 description: OCIRepository resources must provide Cosign verification and reference a specific key.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxOCIRepositoryCosignVerification%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxOCIRepositoryIgonreSuffixes/Makefile
+++ b/policies/FluxOCIRepositoryIgonreSuffixes/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxOCIRepositoryIgonreSuffixes/artifacthub-pkg.yml
+++ b/policies/FluxOCIRepositoryIgonreSuffixes/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: ocirepository-ignore-suffixes
 displayName: OCIRepository Ignore Suffixes
-createdAt: 2025-03-03T13:09:36.550423178Z
+createdAt: 2025-03-04T11:58:05.342507909Z
 description: OCIRepository resources must include specific suffixes in the spec.ignore field which determines the files to be ignored before making a commit..
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -20,7 +20,7 @@ keywords:
 - suffixes
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxOCIRepositoryIgonreSuffixes%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxOCIRepositoryLayerSelector/Makefile
+++ b/policies/FluxOCIRepositoryLayerSelector/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxOCIRepositoryLayerSelector/artifacthub-pkg.yml
+++ b/policies/FluxOCIRepositoryLayerSelector/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: ocirepository-layer-selector
 displayName: OCIRepository Layer Selector
-createdAt: 2025-03-03T13:09:36.620443312Z
+createdAt: 2025-03-04T11:58:05.394984932Z
 description: OCIRepository layer selector must only reference predefined media/operation type.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxOCIRepositoryLayerSelector%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxOCIRepositoryNotLatest/Makefile
+++ b/policies/FluxOCIRepositoryNotLatest/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxOCIRepositoryNotLatest/artifacthub-pkg.yml
+++ b/policies/FluxOCIRepositoryNotLatest/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: ocirepository-not-latest
 displayName: OCIRepository Not Latest Tag
-createdAt: 2025-03-03T13:09:36.685835698Z
+createdAt: 2025-03-04T11:58:05.446603656Z
 description: OCIRepository resources must not use 'latest' as a tag reference.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxOCIRepositoryNotLatest%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxOCIRepositoryOrganizationDomains/Makefile
+++ b/policies/FluxOCIRepositoryOrganizationDomains/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxOCIRepositoryOrganizationDomains/artifacthub-pkg.yml
+++ b/policies/FluxOCIRepositoryOrganizationDomains/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: ocirepository-organization-domains
 displayName: OCIRepository Organization Domains
-createdAt: 2025-03-03T13:09:36.750916659Z
+createdAt: 2025-03-04T11:58:05.498915979Z
 description: OCIRepository resources must only be from allowed organization domains.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxOCIRepositoryOrganizationDomains%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxOCIRepositoryPatchAnnotation/Makefile
+++ b/policies/FluxOCIRepositoryPatchAnnotation/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxOCIRepositoryPatchAnnotation/artifacthub-pkg.yml
+++ b/policies/FluxOCIRepositoryPatchAnnotation/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: ocirepository-patch-annotation
 displayName: OCIRepository Patch Annotation
-createdAt: 2025-03-03T13:09:36.817009211Z
+createdAt: 2025-03-04T11:58:05.550525577Z
 description: OCIRepository resources must have a patch annotation that matches the provider.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxOCIRepositoryPatchAnnotation%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxResourceReconcileInterval/Makefile
+++ b/policies/FluxResourceReconcileInterval/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxResourceReconcileInterval/artifacthub-pkg.yml
+++ b/policies/FluxResourceReconcileInterval/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: resource-reconcile-interval
 displayName: Resource Reconcile Interval Must Be Set Between Lower and Upper Bound
-createdAt: 2025-03-03T13:09:36.885474477Z
+createdAt: 2025-03-04T11:58:05.602616955Z
 description: The reconcile interval of a Resource must be set between a lower and upper bound, lower_bound & upper_bound must be in seconds .
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxResourceReconcileInterval%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/FluxResourceWaiverList/Makefile
+++ b/policies/FluxResourceWaiverList/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/FluxResourceWaiverList/artifacthub-pkg.yml
+++ b/policies/FluxResourceWaiverList/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: resource-suspend-waiver
 displayName: Resource Suspend Waiver
-createdAt: 2025-03-03T13:09:36.951432322Z
+createdAt: 2025-03-04T11:58:05.65382175Z
 description: Resource cannot be suspended unless it's on the waiver list.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -18,7 +18,7 @@ keywords:
 - flux
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/FluxResourceWaiverList%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/IstioGatewayHosts/Makefile
+++ b/policies/IstioGatewayHosts/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/IstioGatewayHosts/artifacthub-pkg.yml
+++ b/policies/IstioGatewayHosts/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: istio-gateway-approved-hosts
 displayName: Istio Gateway Approved Hosts
-createdAt: 2025-03-03T13:09:37.021886554Z
+createdAt: 2025-03-04T11:58:05.705866117Z
 description: "### Istio Gateway Approved Hosts\nThis ensures you are only serving traffic for approved hostnames. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/istio-gateway-approved-hosts:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/IstioGatewayHosts%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/IstioNamespaceLabelInjection/Makefile
+++ b/policies/IstioNamespaceLabelInjection/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/IstioNamespaceLabelInjection/artifacthub-pkg.yml
+++ b/policies/IstioNamespaceLabelInjection/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: istio-injected-namespaces
 displayName: Istio Injected Namespaces
-createdAt: 2025-03-03T13:09:37.08792543Z
+createdAt: 2025-03-04T11:58:05.758160194Z
 description: "# Istio-Injected Namespaces\nSpecify namespaces you would like to be labeld with `istio-injected: enabled`. Namespaces with this label with automatically deploy a Istio sidecar with each pod. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/istio-injected-namespaces:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/IstioNamespaceLabelInjection%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/NamespaceLimitRangeMinMax/Makefile
+++ b/policies/NamespaceLimitRangeMinMax/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/NamespaceLimitRangeMinMax/artifacthub-pkg.yml
+++ b/policies/NamespaceLimitRangeMinMax/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: namespace-resources-limitrange
 displayName: Namespace Resources Limitrange
-createdAt: 2025-03-03T13:09:37.154369029Z
+createdAt: 2025-03-04T11:58:05.811783977Z
 description: |
   When setting up default CPU and Memory values for your namespace, this policy will check if both requests and limits are set. This policy checks for the following:
 
@@ -30,7 +30,7 @@ keywords:
 - soc2-type1
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/NamespaceLimitRangeMinMax%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/NamespacePodQuota/Makefile
+++ b/policies/NamespacePodQuota/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/NamespacePodQuota/artifacthub-pkg.yml
+++ b/policies/NamespacePodQuota/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: namespace-pod-quota
 displayName: Namespace Pod Quota
-createdAt: 2025-03-03T13:09:37.219467412Z
+createdAt: 2025-03-04T11:58:05.864348718Z
 description: "When using a pod quota ensure setting the proper value for the quantity of pods you wish to have in your namespace. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/namespace-pod-quota:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/NamespacePodQuota%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/NamespaceResourceQuotas/Makefile
+++ b/policies/NamespaceResourceQuotas/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/NamespaceResourceQuotas/artifacthub-pkg.yml
+++ b/policies/NamespaceResourceQuotas/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: resource-quota-setting-is-missing
 displayName: Resource Quota Setting Is Missing
-createdAt: 2025-03-03T13:09:37.28683669Z
+createdAt: 2025-03-04T11:58:05.919977805Z
 description: |
   When creating resource quotas per namespace, ensure CPU and Memory requests and limits are set.
 license: Apache-2.0
@@ -19,7 +19,7 @@ keywords:
 - soc2-type1
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/NamespaceResourceQuotas%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/NetworkPolicyAllowEgressFromNamespaceToNamespace/Makefile
+++ b/policies/NetworkPolicyAllowEgressFromNamespaceToNamespace/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/NetworkPolicyAllowEgressFromNamespaceToNamespace/artifacthub-pkg.yml
+++ b/policies/NetworkPolicyAllowEgressFromNamespaceToNamespace/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: network-allow-egress-traffic-from-namespace-to-another
 displayName: Network Allow Egress Traffic From Namespace To Another
-createdAt: 2025-03-03T13:09:37.352139981Z
+createdAt: 2025-03-04T11:58:05.972715719Z
 description: "If you are using a CNI that allows for Network Policies, you can use this Policy to allow Egress traffic from one namespace to another.\n\nBy default, if no policies exist in a namespace, then all ingress and egress traffic is allowed to and from pods in that namespace. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/network-allow-egress-traffic-from-namespace-to-another:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/NetworkPolicyAllowEgressFromNamespaceToNamespace%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/NetworkPolicyAllowIngressFromNamespaceToNamespace/Makefile
+++ b/policies/NetworkPolicyAllowIngressFromNamespaceToNamespace/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/NetworkPolicyAllowIngressFromNamespaceToNamespace/artifacthub-pkg.yml
+++ b/policies/NetworkPolicyAllowIngressFromNamespaceToNamespace/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: network-allow-ingress-traffic-from-namespace-to-another
 displayName: Network Allow Ingress Traffic From Namespace To Another
-createdAt: 2025-03-03T13:09:37.420785045Z
+createdAt: 2025-03-04T11:58:06.02516259Z
 description: "If you are using a CNI that allows for Network Policies, you can use this Policy to allow Ingress traffic from one namespace to another.\n\nBy default, if no policies exist in a namespace, then all ingress and egress traffic is allowed to and from pods in that namespace. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/network-allow-ingress-traffic-from-namespace-to-another:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/NetworkPolicyAllowIngressFromNamespaceToNamespace%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/NetworkPolicyBlockIngressAllToNamespaceFromCIDR/Makefile
+++ b/policies/NetworkPolicyBlockIngressAllToNamespaceFromCIDR/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/NetworkPolicyBlockIngressAllToNamespaceFromCIDR/artifacthub-pkg.yml
+++ b/policies/NetworkPolicyBlockIngressAllToNamespaceFromCIDR/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: network-block-all-ingress-traffic-to-namespace-from-cidr-block
 displayName: Network Block All Ingress Traffic To Namespace From CIDR Block
-createdAt: 2025-03-03T13:09:37.487898364Z
+createdAt: 2025-03-04T11:58:06.076697422Z
 description: "If you are using a CNI that allows for Network Policies, you can use this Policy to block all Egress traffic from a specified namespace to a CIDR block of IP addresses. \n\nBy default, if no policies exist in a namespace, then all ingress and egress traffic is allowed to and from pods in that namespace. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/network-block-all-ingress-traffic-to-namespace-from-cidr-block:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/NetworkPolicyBlockIngressAllToNamespaceFromCIDR%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/PersistentVolumeAccessModes/Makefile
+++ b/policies/PersistentVolumeAccessModes/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/PersistentVolumeAccessModes/artifacthub-pkg.yml
+++ b/policies/PersistentVolumeAccessModes/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: persistent-volume-access-modes
 displayName: Persistent Volume Access Modes
-createdAt: 2025-03-03T13:09:37.556612826Z
+createdAt: 2025-03-04T11:58:06.128572205Z
 description: |
   A PersistentVolume can be mounted on a host in any way supported by the resource provider. As shown in the table below, providers will have different capabilities and each PV's access modes are set to the specific modes supported by that particular volume. For example, NFS can support multiple read/write clients, but a specific NFS PV might be exported on the server as read-only. Each PV gets its own set of access modes describing that specific PV's capabilities.
 
@@ -24,7 +24,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/persistent-volume-access-modes:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/PersistentVolumeAccessModes%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/PersistentVolumeClaimSnapshot/Makefile
+++ b/policies/PersistentVolumeClaimSnapshot/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/PersistentVolumeClaimSnapshot/artifacthub-pkg.yml
+++ b/policies/PersistentVolumeClaimSnapshot/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: persistent-volume-claim-snapshot
 displayName: Persistent Volume Claim Snapshot
-createdAt: 2025-03-03T13:09:37.619688219Z
+createdAt: 2025-03-04T11:58:06.180359788Z
 description: "This Policy checks for a PVC Snapshot. \n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/persistent-volume-claim-snapshot:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/PersistentVolumeClaimSnapshot%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/RBACProhibitListOnSecrets/Makefile
+++ b/policies/RBACProhibitListOnSecrets/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/RBACProhibitListOnSecrets/artifacthub-pkg.yml
+++ b/policies/RBACProhibitListOnSecrets/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: rbac-prohibit-list-secrets
 displayName: Rbac Prohibit List On Secrets
-createdAt: 2025-03-03T13:09:37.686970684Z
+createdAt: 2025-03-04T11:58:06.232124175Z
 description: |
   This Policy will violate if any RBAC ClusterRoles or Roles are designated with 'list' verb on 'secrets' resource.
 license: Apache-2.0
@@ -17,7 +17,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/rbac-prohibit-list-secrets:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/RBACProhibitListOnSecrets%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/RBACProhibitWatchOnSecrets/Makefile
+++ b/policies/RBACProhibitWatchOnSecrets/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/RBACProhibitWatchOnSecrets/artifacthub-pkg.yml
+++ b/policies/RBACProhibitWatchOnSecrets/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: rbac-prohibit-watch-secrets
 displayName: Rbac Prohibit Watch On Secrets
-createdAt: 2025-03-03T13:09:37.754330655Z
+createdAt: 2025-03-04T11:58:06.283147184Z
 description: |
   This Policy will violate if any RBAC ClusterRoles or Roles are designated with 'watch' verb on 'secrets' resource.
 license: Apache-2.0
@@ -17,7 +17,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/rbac-prohibit-watch-secrets:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/RBACProhibitWatchOnSecrets%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/RBACProhibitWildcardOnSecrets/Makefile
+++ b/policies/RBACProhibitWildcardOnSecrets/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/RBACProhibitWildcardOnSecrets/artifacthub-pkg.yml
+++ b/policies/RBACProhibitWildcardOnSecrets/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: rbac-prohibit-wildcard-secrets
 displayName: Rbac Prohibit Wildcard On Secrets
-createdAt: 2025-03-03T13:09:37.823771113Z
+createdAt: 2025-03-04T11:58:06.335632952Z
 description: |
   This Policy will violate if any RBAC ClusterRoles or Roles are designated with 'wildcard' verb on 'secrets' resource.
 license: Apache-2.0
@@ -17,7 +17,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/rbac-prohibit-wildcard-secrets:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/RBACProhibitWildcardOnSecrets%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/RBACProhibitWildcardsOnPolicyRuleResources/Makefile
+++ b/policies/RBACProhibitWildcardsOnPolicyRuleResources/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/RBACProhibitWildcardsOnPolicyRuleResources/artifacthub-pkg.yml
+++ b/policies/RBACProhibitWildcardsOnPolicyRuleResources/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: rbac-prohibit-wildcards-policyrule-resources
 displayName: Rbac Prohibit Wildcards on Policy Rule Resources
-createdAt: 2025-03-03T13:09:37.888895413Z
+createdAt: 2025-03-04T11:58:06.388111472Z
 description: "This Policy prohibits various resources from being set with wildcards for Role or ClusterRole resources, except for the `cluster-admin` ClusterRole. It will check each resource specified for the verb specified. The wildcards will be checked in:\n\n### Resources\nIn the Kubernetes API, most resources are represented and accessed using a string representation of their object name, such as pods for a Pod. RBAC refers to resources using exactly the same name that appears in the URL for the relevant API endpoint. \n\n### Verbs\nAPI verbs like get, list, create, update, patch, watch, delete, and deletecollection are used for resource requests. \n\n### API Groups\nThe API Group being accessed (for resource requests only).\n\n### Non Resource URLs\nRequests to endpoints other than /api/v1/... or /apis/<group>/<version>/... are considered \"non-resource requests\", and use the lower-cased HTTP method of the request as the verb.\n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/rbac-prohibit-wildcards-policyrule-resources:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/RBACProhibitWildcardsOnPolicyRuleResources%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |

--- a/policies/RBACProhibitWildcardsOnPolicyRuleVerbs/Makefile
+++ b/policies/RBACProhibitWildcardsOnPolicyRuleVerbs/Makefile
@@ -27,7 +27,7 @@ artifacthub-pkg.yml: metadata.yml
 		To use the latest tag, use the following command:  \
 		make VERSION=$$(git describe --tags --abbrev=0 | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2-) artifacthub-pkg.yml)
 	kwctl scaffold artifacthub \
-	    --metadata-path metadata.yml --version $(VERSION) --output artifacthub-pkg.yml
+	    --metadata-path metadata.yml --version $(VERSION) --gh-release-tag $(notdir $(CURDIR))/v$(VERSION) --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm

--- a/policies/RBACProhibitWildcardsOnPolicyRuleVerbs/artifacthub-pkg.yml
+++ b/policies/RBACProhibitWildcardsOnPolicyRuleVerbs/artifacthub-pkg.yml
@@ -7,7 +7,7 @@
 version: 1.0.0
 name: rbac-prohibit-wildcards-policyrule-verbs
 displayName: Rbac Prohibit Wildcards on Policy Rule Verbs
-createdAt: 2025-03-03T13:09:37.955011634Z
+createdAt: 2025-03-04T11:58:06.439527808Z
 description: "This Policy prohibits various resources from being set with wildcards for Role or ClusterRole resources, except for the `cluster-admin` ClusterRole. It will check each resource specified for the verb specified. The wildcards will be checked in:\n\n### Resources\nIn the Kubernetes API, most resources are represented and accessed using a string representation of their object name, such as pods for a Pod. RBAC refers to resources using exactly the same name that appears in the URL for the relevant API endpoint. \n\n### Verbs\nAPI verbs like get, list, create, update, patch, watch, delete, and deletecollection are used for resource requests. \n\n### API Groups\nThe API Group being accessed (for resource requests only).\n\n### Non Resource URLs\nRequests to endpoints other than /api/v1/... or /apis/<group>/<version>/... are considered \"non-resource requests\", and use the lower-cased HTTP method of the request as the verb.\n"
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rego-policies-library
@@ -16,7 +16,7 @@ containersImages:
   image: ghcr.io/kubewarden/policies/rbac-prohibit-wildcards-policyrule-verbs:v1.0.0
 links:
 - name: policy
-  url: https://github.com/kubewarden/rego-policies-library/releases/download/v1.0.0/policy.wasm
+  url: https://github.com/kubewarden/rego-policies-library/releases/download/RBACProhibitWildcardsOnPolicyRuleVerbs%2Fv1.0.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rego-policies-library
 install: |


### PR DESCRIPTION
## Description

Following up on https://github.com/kubewarden/kwctl/pull/1105, this adds the `--gh-release-tag` option to `kwctl scaffold artifacthub` in the Makefile and regenerates `artifacthub-pkg.yml`.