### PR TITLE
ci: dispatch release policy catalog workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   calculate-policy-from-tag:
     runs-on: ubuntu-latest
     outputs:
+      policy-name: ${{ steps.calculate-vars.outputs.policy_name }}
       policy-working-dir: ${{ steps.calculate-vars.outputs.policy_working_dir }}
       policy-version: ${{ steps.calculate-vars.outputs.policy_version }}
       policy-id: ${{ steps.calculate-vars.outputs.policy_id }}
@@ -19,14 +20,16 @@ jobs:
         run: |
           # we expect a tag on the form of: ControllerContainerBlockSSHPort/v0.1.0
           # and want:
+          #   policy_name="ControllerContainerBlockSSHPort"
           #   policy_working_dir="policies/ControllerContainerBlockSSHPort"
           #   policy_version="0.1.0"
           #   policy_id="controller-container-block-ssh-port" # from metadata.yml
-          policy_dir_name=$( echo ${{ github.ref_name }} | sed 's/\(.*\)\/\(.*\)$/\1/' )
-          policy_working_dir=policies/"$policy_dir_name"
+          policy_name=$( echo ${{ github.ref_name }} | sed 's/\(.*\)\/\(.*\)$/\1/' )
+          policy_working_dir=policies/"$policy_name"
           policy_ociUrl=$(yq -r '.annotations."io.kubewarden.policy.ociUrl"' $policy_working_dir/metadata.yml)
           policy_id=${policy_ociUrl##*/}
 
+          echo "policy_name=$policy_name" >> $GITHUB_OUTPUT
           echo "policy_id=$policy_id" >> $GITHUB_OUTPUT
           echo "policy_working_dir=$policy_working_dir" >> $GITHUB_OUTPUT
           echo "policy_version=$( echo ${{ github.ref_name }} | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2- )" >> $GITHUB_OUTPUT
@@ -39,7 +42,7 @@ jobs:
   unit-tests:
     needs: calculate-policy-from-tag
     name: run unit tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rego.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rego.yml@5c66301791d03f238a7366a0fee1e34087ec16b1 # v4.1.0
     with:
       policy-working-dir: ${{ needs.calculate-policy-from-tag.outputs.policy-working-dir }}
 
@@ -52,8 +55,13 @@ jobs:
       packages: write
       # Required by cosign keyless signing
       id-token: write
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rego.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rego.yml@5c66301791d03f238a7366a0fee1e34087ec16b1 # v4.1.0
     with:
       oci-target: ghcr.io/${{ github.repository_owner }}/policies/${{ needs.calculate-policy-from-tag.outputs.policy-id }}
+      policy-name: ${{ needs.calculate-policy-from-tag.outputs.policy-name }}
       policy-working-dir: ${{ needs.calculate-policy-from-tag.outputs.policy-working-dir }}
       policy-version: ${{ needs.calculate-policy-from-tag.outputs.policy-version }}
+      release-catalog: true
+    secrets:
+      # Required to dispatch the release event to the policy-catalog repository
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
## Description  

This PR upgrades GitHub Actions to `v4.1.0` and enables the `release-catalog` input parameter by setting it to `true`, while also specifying the `policy-name` and the `WORKFLOW_PAT` secret.  

As a result, releasing a policy from the monorepo will automatically update the policy catalog.