### PR TITLE
fix: add default directives

### DIFF
--- a/policies/ControllerAffinityNodeSelector/metadata.yml
+++ b/policies/ControllerAffinityNodeSelector/metadata.yml
@@ -18,7 +18,7 @@ annotations:
   io.artifacthub.displayName: Affinity Node Selector
   io.artifacthub.resources: CronJob, DaemonSet, Deployment, Job, Pod, StatefulSet
   io.kubewarden.policy.title: affinity-node-selector
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "This Policy allows setting a key and value for `nodeSelector` when assigning pods to nodes. \n\n`nodeSelector` is a field of PodSpec. It specifies a map of key-value pairs. For the pod to be eligible to scheduled on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/affinity-node-selector

--- a/policies/ControllerAffinityNodeSelector/policy.rego
+++ b/policies/ControllerAffinityNodeSelector/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 key := input.parameters.key
 value := input.parameters.value
 exclude_namespaces := input.parameters.exclude_namespaces

--- a/policies/ControllerContainerBlockSSHPort/metadata.yml
+++ b/policies/ControllerContainerBlockSSHPort/metadata.yml
@@ -19,7 +19,7 @@ annotations:
   io.artifacthub.keywords: pci-dss
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: containers-block-ssh-port
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: |
     This Policy checks if the container is exposing ssh port.
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>

--- a/policies/ControllerContainerBlockSSHPort/policy.rego
+++ b/policies/ControllerContainerBlockSSHPort/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default container_port := 22
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 container_port := input.parameters.container_port
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/ControllerContainerBlockSysctls/metadata.yml
+++ b/policies/ControllerContainerBlockSysctls/metadata.yml
@@ -19,7 +19,7 @@ annotations:
   io.artifacthub.keywords: pci-dss, cis-benchmark, mitre-attack, nist800-190, gdpr, default
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: container-block-sysctl
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Setting sysctls can allow containers unauthorized escalated privileges to a Kubernetes node. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/container-block-sysctl

--- a/policies/ControllerContainerBlockSysctls/policy.rego
+++ b/policies/ControllerContainerBlockSysctls/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := ["kube-system"]
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/ControllerContainerBlockSysctls_CVE-2022-0811/metadata.yml
+++ b/policies/ControllerContainerBlockSysctls_CVE-2022-0811/metadata.yml
@@ -19,7 +19,7 @@ annotations:
   io.artifacthub.keywords: pci-dss, cis-benchmark, mitre-attack, nist800-190, gdpr, default
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: container-block-sysctl.cve-2022-0811
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Setting sysctls can allow containers unauthorized escalated privileges to a Kubernetes node. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/container-block-sysctl.cve-2022-0811

--- a/policies/ControllerContainerBlockSysctls_CVE-2022-0811/policy.rego
+++ b/policies/ControllerContainerBlockSysctls_CVE-2022-0811/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := ["kube-system"]
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/ControllerContainerRunningAsRoot/metadata.yml
+++ b/policies/ControllerContainerRunningAsRoot/metadata.yml
@@ -19,7 +19,7 @@ annotations:
   io.artifacthub.keywords: pci-dss, cis-benchmark, mitre-attack, nist800-190, gdpr, default
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: container-running-as-root
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Running as root gives the container full access to all resources in the VM it is running on. Containers should not run with such access rights unless required by design. This Policy enforces that the `securityContext.runAsNonRoot` attribute is set to `true`. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/container-running-as-root

--- a/policies/ControllerContainerRunningAsRoot/policy.rego
+++ b/policies/ControllerContainerRunningAsRoot/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := ["kube-system"]
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/ControllerContainerRunningAsUser/metadata.yml
+++ b/policies/ControllerContainerRunningAsUser/metadata.yml
@@ -19,7 +19,7 @@ annotations:
   io.artifacthub.keywords: pci-dss, cis-benchmark, mitre-attack, nist800-190, gdpr, default
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: container-running-as-user
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Containers has a feature in which you specify the ID of the user which all processes in the container will run with. This Policy enforces that the `securityContext.runAsUser` attribute is set to a uid greater than root uid. Running as root user gives the container full access to all resources in the VM it is running on. Containers should not run with such access rights unless required by design. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/container-running-as-user

--- a/policies/ControllerContainerRunningAsUser/policy.rego
+++ b/policies/ControllerContainerRunningAsUser/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default uid := 0
+default exclude_namespaces := ["kube-system"]
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 uid := input.parameters.uid
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/ControllerImageName/metadata.yml
+++ b/policies/ControllerImageName/metadata.yml
@@ -18,7 +18,7 @@ annotations:
   io.artifacthub.displayName: Containers Block Specific Image Names
   io.artifacthub.resources: CronJob, DaemonSet, Deployment, Job, Pod, StatefulSet
   io.kubewarden.policy.title: containers-block-specific-image-names
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "This Policy prohibits images with certain image names from being deployed by specifying a list of unapproved names. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/containers-block-specific-image-names

--- a/policies/ControllerImageName/policy.rego
+++ b/policies/ControllerImageName/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 restricted_image_names := input.parameters.restricted_image_names
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/ControllerMissingKubernetesAppComponentLabel/metadata.yml
+++ b/policies/ControllerMissingKubernetesAppComponentLabel/metadata.yml
@@ -18,7 +18,7 @@ annotations:
   io.artifacthub.displayName: Missing Kubernetes App Component Label
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: missing-kubernetes-app-component-label
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\t\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/missing-kubernetes-app-component-label

--- a/policies/ControllerMissingKubernetesAppComponentLabel/policy.rego
+++ b/policies/ControllerMissingKubernetesAppComponentLabel/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/ControllerMissingKubernetesAppCreatedByLabel/metadata.yml
+++ b/policies/ControllerMissingKubernetesAppCreatedByLabel/metadata.yml
@@ -18,7 +18,7 @@ annotations:
   io.artifacthub.displayName: Missing Kubernetes App Created By Label
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: missing-kubernetes-app-created-by-label
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\t\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/missing-kubernetes-app-created-by-label

--- a/policies/ControllerMissingKubernetesAppCreatedByLabel/policy.rego
+++ b/policies/ControllerMissingKubernetesAppCreatedByLabel/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/ControllerMissingKubernetesAppInstanceLabel/metadata.yml
+++ b/policies/ControllerMissingKubernetesAppInstanceLabel/metadata.yml
@@ -18,7 +18,7 @@ annotations:
   io.artifacthub.displayName: Missing Kubernetes App Instance Label
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: missing-kubernetes-app-instance-label
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/missing-kubernetes-app-instance-label

--- a/policies/ControllerMissingKubernetesAppInstanceLabel/policy.rego
+++ b/policies/ControllerMissingKubernetesAppInstanceLabel/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/ControllerMissingKubernetesAppLabel/metadata.yml
+++ b/policies/ControllerMissingKubernetesAppLabel/metadata.yml
@@ -18,7 +18,7 @@ annotations:
   io.artifacthub.displayName: Missing Kubernetes App Label
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: missing-kubernetes-app-label
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/missing-kubernetes-app-label

--- a/policies/ControllerMissingKubernetesAppLabel/policy.rego
+++ b/policies/ControllerMissingKubernetesAppLabel/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/ControllerMissingKubernetesAppManagedByLabel/metadata.yml
+++ b/policies/ControllerMissingKubernetesAppManagedByLabel/metadata.yml
@@ -18,7 +18,7 @@ annotations:
   io.artifacthub.displayName: Missing Kubernetes App Managed By Label
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: missing-kubernetes-app-managed-by-label
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\t\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/missing-kubernetes-app-managed-by-label

--- a/policies/ControllerMissingKubernetesAppManagedByLabel/policy.rego
+++ b/policies/ControllerMissingKubernetesAppManagedByLabel/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/ControllerMissingKubernetesAppPartOfLabel/metadata.yml
+++ b/policies/ControllerMissingKubernetesAppPartOfLabel/metadata.yml
@@ -18,7 +18,7 @@ annotations:
   io.artifacthub.displayName: Missing Kubernetes App Part Of Label
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: missing-kubernetes-app-part-of-label
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\t\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/missing-kubernetes-app-part-of-label

--- a/policies/ControllerMissingKubernetesAppPartOfLabel/policy.rego
+++ b/policies/ControllerMissingKubernetesAppPartOfLabel/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/ControllerMissingKubernetesAppVersionLabel/metadata.yml
+++ b/policies/ControllerMissingKubernetesAppVersionLabel/metadata.yml
@@ -18,7 +18,7 @@ annotations:
   io.artifacthub.displayName: Missing Kubernetes App Version Label
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: missing-kubernetes-app-version-label
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\t\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/missing-kubernetes-app-version-label

--- a/policies/ControllerMissingKubernetesAppVersionLabel/policy.rego
+++ b/policies/ControllerMissingKubernetesAppVersionLabel/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/ControllerMissingLabelValue/metadata.yml
+++ b/policies/ControllerMissingLabelValue/metadata.yml
@@ -14,7 +14,7 @@ annotations:
   io.artifacthub.displayName: Metadata Missing Label And Value
   io.artifacthub.resources: DaemonSet, Deployment, Job, StatefulSet
   io.kubewarden.policy.title: metadata-missing-label-and-value
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensures a key and value are set in the entity's `metadata.labels` path. The Policy detects the presence of the following: \n\n### label\nA label key of your choosing. \n\n### value\nA label value of your choosing.\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/metadata-missing-label-and-value

--- a/policies/ControllerMissingLabelValue/policy.rego
+++ b/policies/ControllerMissingLabelValue/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 label := input.parameters.label
 value := input.parameters.value
 exclude_namespaces := input.parameters.exclude_namespaces

--- a/policies/ControllerMissingNamespace/metadata.yml
+++ b/policies/ControllerMissingNamespace/metadata.yml
@@ -18,7 +18,7 @@ annotations:
   io.artifacthub.displayName: Block Workloads Created Without Specifying Namespace
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: block-workloads-created-without-specifying-namespace
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Using this Policy, you can prohibit workloads from being created in a default namespace due to the lack of a namespace label. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/block-workloads-created-without-specifying-namespace

--- a/policies/ControllerMissingNamespace/policy.rego
+++ b/policies/ControllerMissingNamespace/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value
 

--- a/policies/ControllerMissingOwnerLabel/metadata.yml
+++ b/policies/ControllerMissingOwnerLabel/metadata.yml
@@ -18,7 +18,7 @@ annotations:
   io.artifacthub.displayName: Missing Owner Label
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: missing-owner-label
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Custom labels can help enforce organizational standards for each artifact deployed. This Policy ensure a custom label key is set in the entity's `metadata`. The Policy detects the presence of the following: \n\n### owner\nA label key of `owner` will help identify who the owner of this entity is. \n\n### app.kubernetes.io/name\nThe name of the application\t\n\n### app.kubernetes.io/instance\nA unique name identifying the instance of an application\t  \n\n### app.kubernetes.io/version\nThe current version of the application (e.g., a semantic version, revision hash, etc.)\n\n### app.kubernetes.io/part-of\nThe name of a higher level application this one is part of\t\n\n### app.kubernetes.io/managed-by\nThe tool being used to manage the operation of an application\t\n\n### app.kubernetes.io/created-by\nThe controller/user who created this resource\t\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/missing-owner-label

--- a/policies/ControllerMissingOwnerLabel/policy.rego
+++ b/policies/ControllerMissingOwnerLabel/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/ControllerMissingSecurityContext/metadata.yml
+++ b/policies/ControllerMissingSecurityContext/metadata.yml
@@ -19,7 +19,7 @@ annotations:
   io.artifacthub.keywords: pci-dss, cis-benchmark, mitre-attack, nist800-190, gdpr, default
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: containers-missing-security-context
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: |
     This Policy checks if the container is missing securityContext while there is no securityContext defined on the Pod level as well. The security settings that are specified on the Pod level apply to all containers in the Pod.
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>

--- a/policies/ControllerMissingSecurityContext/policy.rego
+++ b/policies/ControllerMissingSecurityContext/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := ["kube-system"]
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/ControllerProhibitNamespace/metadata.yml
+++ b/policies/ControllerProhibitNamespace/metadata.yml
@@ -19,7 +19,7 @@ annotations:
   io.artifacthub.keywords: cis-benchmark, soc2-type1
   io.artifacthub.resources: Pod, Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: containers-should-not-run-in-namespace
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "This Policy ensure workloads are not running in a specified namespace. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/containers-should-not-run-in-namespace

--- a/policies/ControllerProhibitNamespace/policy.rego
+++ b/policies/ControllerProhibitNamespace/policy.rego
@@ -1,5 +1,9 @@
 package policy
 
+default custom_namespace := "default"
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 custom_namespace := input.parameters.custom_namespace
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxBucketApprovedRegion/metadata.yml
+++ b/policies/FluxBucketApprovedRegion/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: Bucket
   io.kubewarden.policy.title: bucket-approved-region
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Bucket region must be one of the approved regions."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/bucket-approved-region

--- a/policies/FluxBucketApprovedRegion/policy.rego
+++ b/policies/FluxBucketApprovedRegion/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxBucketEndpointDomain/metadata.yml
+++ b/policies/FluxBucketEndpointDomain/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: Bucket
   io.kubewarden.policy.title: bucket-endpoint-domain
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Bucket endpoint domain must be one of the trusted domains."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/bucket-endpoint-domain

--- a/policies/FluxBucketEndpointDomain/policy.rego
+++ b/policies/FluxBucketEndpointDomain/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxBucketInsecure/metadata.yml
+++ b/policies/FluxBucketInsecure/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: Bucket
   io.kubewarden.policy.title: bucket-insecure-connections
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Ensure that Bucket objects do not use insecure connections"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/bucket-insecure-connections

--- a/policies/FluxBucketInsecure/policy.rego
+++ b/policies/FluxBucketInsecure/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxGitRepositoryIgonreSuffixes/metadata.yml
+++ b/policies/FluxGitRepositoryIgonreSuffixes/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: GitRepository
   io.kubewarden.policy.title: gitrepository-ignore-suffixes
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "GitRepository resources must include specific suffixes in the spec.ignore field which determines the files to be ignored before making a commit."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/gitrepository-ignore-suffixes

--- a/policies/FluxGitRepositoryIgonreSuffixes/policy.rego
+++ b/policies/FluxGitRepositoryIgonreSuffixes/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 suffixes := input.parameters.suffixes
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/FluxGitRepositoryOrganizationDomains/metadata.yml
+++ b/policies/FluxGitRepositoryOrganizationDomains/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: GitRepository
   io.kubewarden.policy.title: gitrepository-organization-domains
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "GitRepository resources must only be from allowed organization domains."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/gitrepository-organization-domains

--- a/policies/FluxGitRepositoryOrganizationDomains/policy.rego
+++ b/policies/FluxGitRepositoryOrganizationDomains/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 domains := input.parameters.domains
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/FluxGitRepositorySpecificBranch/metadata.yml
+++ b/policies/FluxGitRepositorySpecificBranch/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: GitRepository
   io.kubewarden.policy.title: gitrepository-specific-branch
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "GitRepository resources must reference a specific branch, e.g. 'main'."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/gitrepository-specific-branch

--- a/policies/FluxGitRepositorySpecificBranch/policy.rego
+++ b/policies/FluxGitRepositorySpecificBranch/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 branch := input.parameters.branch
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/FluxGitRepositoryUntrustedDomains/metadata.yml
+++ b/policies/FluxGitRepositoryUntrustedDomains/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: GitRepository
   io.kubewarden.policy.title: gitrepository-untrusted-domains
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "GitRepository resources must not use targets from untrusted domains."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/gitrepository-untrusted-domains

--- a/policies/FluxGitRepositoryUntrustedDomains/policy.rego
+++ b/policies/FluxGitRepositoryUntrustedDomains/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 untrusted_domains := input.parameters.untrusted_domains
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/FluxHelmChartCosignVerification/metadata.yml
+++ b/policies/FluxHelmChartCosignVerification/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmChart
   io.kubewarden.policy.title: helm-chart-cosign-verification
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "HelmChart objects must provide cosign verification and reference a secret containing the Cosign public keys of trusted authors"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-chart-cosign-verification

--- a/policies/FluxHelmChartCosignVerification/policy.rego
+++ b/policies/FluxHelmChartCosignVerification/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxHelmChartValuesFormat/metadata.yml
+++ b/policies/FluxHelmChartValuesFormat/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmChart
   io.kubewarden.policy.title: helm-chart-values-files-format
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "HelmChart must reference values files in the following format: 'xxx=values.yaml'."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-chart-values-files-format

--- a/policies/FluxHelmChartValuesFormat/policy.rego
+++ b/policies/FluxHelmChartValuesFormat/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxHelmReleaseMaxHistory/metadata.yml
+++ b/policies/FluxHelmReleaseMaxHistory/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRelease
   io.kubewarden.policy.title: helm-release-max-history
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "HelmRelease maxHistory cannot exceed the specified value."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-release-max-history

--- a/policies/FluxHelmReleaseMaxHistory/policy.rego
+++ b/policies/FluxHelmReleaseMaxHistory/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default max_history := 100
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxHelmReleaseNameSpaceMatch/metadata.yml
+++ b/policies/FluxHelmReleaseNameSpaceMatch/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRelease
   io.kubewarden.policy.title: helm-release-namespace-match
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "HelmRelease storageNamespace and targetNamespace must match."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-release-namespace-match

--- a/policies/FluxHelmReleaseNameSpaceMatch/policy.rego
+++ b/policies/FluxHelmReleaseNameSpaceMatch/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxHelmReleasePostRenderer/metadata.yml
+++ b/policies/FluxHelmReleasePostRenderer/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRelease
   io.kubewarden.policy.title: helm-release-post-renderer
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "HelmRelease must not have post-renderers enabled."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-release-post-renderer

--- a/policies/FluxHelmReleasePostRenderer/policy.rego
+++ b/policies/FluxHelmReleasePostRenderer/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxHelmReleaseRemediationRetries/metadata.yml
+++ b/policies/FluxHelmReleaseRemediationRetries/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRelease
   io.kubewarden.policy.title: helm-release-remediation-retries
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "HelmRelease remediation retries must be within the specified lower and upper bounds."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-release-remediation-retries

--- a/policies/FluxHelmReleaseRemediationRetries/policy.rego
+++ b/policies/FluxHelmReleaseRemediationRetries/policy.rego
@@ -2,6 +2,12 @@ package policy
 
 import future.keywords.in
 
+default lower_bound := 1
+default upper_bound := 10
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxHelmReleaseRollback/metadata.yml
+++ b/policies/FluxHelmReleaseRollback/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRelease
   io.kubewarden.policy.title: helm-release-rollback
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "The rollback feature of a HelmRelease should be disabled."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-release-rollback

--- a/policies/FluxHelmReleaseRollback/policy.rego
+++ b/policies/FluxHelmReleaseRollback/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxHelmReleaseServiceAccountName/metadata.yml
+++ b/policies/FluxHelmReleaseServiceAccountName/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRelease
   io.kubewarden.policy.title: helm-release-service-account-name
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "HelmRelease serviceAccountName must contain a value from parameters.service_account_names"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-release-service-account-name

--- a/policies/FluxHelmReleaseServiceAccountName/policy.rego
+++ b/policies/FluxHelmReleaseServiceAccountName/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxHelmReleaseStorageNamespace/metadata.yml
+++ b/policies/FluxHelmReleaseStorageNamespace/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRelease
   io.kubewarden.policy.title: helm-release-storage-namespace
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "HelmRelease storageNamespace must contain a value from storage_namespaces."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-release-storage-namespace

--- a/policies/FluxHelmReleaseStorageNamespace/policy.rego
+++ b/policies/FluxHelmReleaseStorageNamespace/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxHelmReleaseTargetNameSpace/metadata.yml
+++ b/policies/FluxHelmReleaseTargetNameSpace/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRelease
   io.kubewarden.policy.title: helm-release-target-namespace
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "HelmRelease targetNamespace must be one of the allowed targetNamespace list."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-release-target-namespace

--- a/policies/FluxHelmReleaseTargetNameSpace/policy.rego
+++ b/policies/FluxHelmReleaseTargetNameSpace/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxHelmReleaseValuesFromConfigMaps/metadata.yml
+++ b/policies/FluxHelmReleaseValuesFromConfigMaps/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRelease
   io.kubewarden.policy.title: helm-release-values-from-configmaps
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "HelmRelease valuesFrom must use correctly configured ConfigMaps."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-release-values-from-configmaps

--- a/policies/FluxHelmReleaseValuesFromConfigMaps/policy.rego
+++ b/policies/FluxHelmReleaseValuesFromConfigMaps/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxHelmRepositoryType/metadata.yml
+++ b/policies/FluxHelmRepositoryType/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRepository
   io.kubewarden.policy.title: helm-repo-type
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "The type of a Helm repository should be OCI."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-repo-type

--- a/policies/FluxHelmRepositoryType/policy.rego
+++ b/policies/FluxHelmRepositoryType/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := ["kube-system"]
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxHelmRepositoryURL/metadata.yml
+++ b/policies/FluxHelmRepositoryURL/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRepository
   io.kubewarden.policy.title: helm-repo-url
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "The URL of a Helm repository should only be from the specified organisation domain."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/helm-repo-url

--- a/policies/FluxHelmRepositoryURL/policy.rego
+++ b/policies/FluxHelmRepositoryURL/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 domains := input.parameters.domains
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/FluxKustomizationDecryptionProvider/metadata.yml
+++ b/policies/FluxKustomizationDecryptionProvider/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: Kustomization
   io.kubewarden.policy.title: kustomization-decryption-provider
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Spec.decryption.provider must be set to one of decryption_providers."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/kustomization-decryption-provider

--- a/policies/FluxKustomizationDecryptionProvider/policy.rego
+++ b/policies/FluxKustomizationDecryptionProvider/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxKustomizationImageTagStandards/metadata.yml
+++ b/policies/FluxKustomizationImageTagStandards/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: Kustomization
   io.kubewarden.policy.title: kustomization-image-tag-standards
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "spec.Images must comply with image tag/semver reference standards."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/kustomization-image-tag-standards

--- a/policies/FluxKustomizationImageTagStandards/policy.rego
+++ b/policies/FluxKustomizationImageTagStandards/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxKustomizationPaths/metadata.yml
+++ b/policies/FluxKustomizationPaths/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: Kustomization
   io.kubewarden.policy.title: kustomization-excluded-paths
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "spec.path cannot be one of excludedPathsList[]"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/kustomization-excluded-paths

--- a/policies/FluxKustomizationPaths/policy.rego
+++ b/policies/FluxKustomizationPaths/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxKustomizationTargetNamespace/metadata.yml
+++ b/policies/FluxKustomizationTargetNamespace/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: Kustomization
   io.kubewarden.policy.title: kustomization-target-namespace
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Kustomization targetNamespace must be one of the allowed targetNamespace list."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/kustomization-target-namespace

--- a/policies/FluxKustomizationTargetNamespace/policy.rego
+++ b/policies/FluxKustomizationTargetNamespace/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxKustomizationVarSubstitution/metadata.yml
+++ b/policies/FluxKustomizationVarSubstitution/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: Kustomization
   io.kubewarden.policy.title: kustomization-var-substitution
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "The property 'spec.postBuild.substitute.var_substitution_enabled' must be disabled."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/kustomization-var-substitution

--- a/policies/FluxKustomizationVarSubstitution/policy.rego
+++ b/policies/FluxKustomizationVarSubstitution/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxKustomizeImagesRequirement/metadata.yml
+++ b/policies/FluxKustomizeImagesRequirement/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: Kustomization
   io.kubewarden.policy.title: kustomization-images-requirement
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "The 'spec.images' field in a Kustomization object must be enabled or disabled based on the policy input images_required."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/kustomization-images-requirement

--- a/policies/FluxKustomizeImagesRequirement/policy.rego
+++ b/policies/FluxKustomizeImagesRequirement/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+default images_required := true
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxKustomizePatchesRequirement/metadata.yml
+++ b/policies/FluxKustomizePatchesRequirement/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: Kustomization
   io.kubewarden.policy.title: kustomization-patches-requirement
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Kustomization patches should be enabled or disabled based on input."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/kustomization-patches-requirement

--- a/policies/FluxKustomizePatchesRequirement/policy.rego
+++ b/policies/FluxKustomizePatchesRequirement/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxKustomizePrune/metadata.yml
+++ b/policies/FluxKustomizePrune/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: Kustomization
   io.kubewarden.policy.title: kustomization-prune
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "The 'spec.prune' field in the Kustomization object must be set according to the input parameter 'prune'."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/kustomization-prune

--- a/policies/FluxKustomizePrune/policy.rego
+++ b/policies/FluxKustomizePrune/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxOCIRepositoryCosignVerification/metadata.yml
+++ b/policies/FluxOCIRepositoryCosignVerification/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: OCIRepository
   io.kubewarden.policy.title: ocirepository-cosign-verification
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "OCIRepository resources must provide Cosign verification and reference a specific key."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/ocirepository-cosign-verification

--- a/policies/FluxOCIRepositoryCosignVerification/policy.rego
+++ b/policies/FluxOCIRepositoryCosignVerification/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxOCIRepositoryIgonreSuffixes/metadata.yml
+++ b/policies/FluxOCIRepositoryIgonreSuffixes/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux, oci, suffixes
   io.artifacthub.resources: OCIRepository
   io.kubewarden.policy.title: ocirepository-ignore-suffixes
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "OCIRepository resources must include specific suffixes in the spec.ignore field which determines the files to be ignored before making a commit.."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/ocirepository-ignore-suffixes

--- a/policies/FluxOCIRepositoryIgonreSuffixes/policy.rego
+++ b/policies/FluxOCIRepositoryIgonreSuffixes/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 suffixes := input.parameters.suffixes
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/FluxOCIRepositoryLayerSelector/metadata.yml
+++ b/policies/FluxOCIRepositoryLayerSelector/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: OCIRepository
   io.kubewarden.policy.title: ocirepository-layer-selector
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "OCIRepository layer selector must only reference predefined media/operation type."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/ocirepository-layer-selector

--- a/policies/FluxOCIRepositoryLayerSelector/policy.rego
+++ b/policies/FluxOCIRepositoryLayerSelector/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default operations := ["extract"]
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 media_types := input.parameters.media_types
 operations := input.parameters.operations
 exclude_namespaces := input.parameters.exclude_namespaces

--- a/policies/FluxOCIRepositoryNotLatest/metadata.yml
+++ b/policies/FluxOCIRepositoryNotLatest/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: OCIRepository
   io.kubewarden.policy.title: ocirepository-not-latest
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "OCIRepository resources must not use 'latest' as a tag reference."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/ocirepository-not-latest

--- a/policies/FluxOCIRepositoryNotLatest/policy.rego
+++ b/policies/FluxOCIRepositoryNotLatest/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxOCIRepositoryOrganizationDomains/metadata.yml
+++ b/policies/FluxOCIRepositoryOrganizationDomains/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: OCIRepository
   io.kubewarden.policy.title: ocirepository-organization-domains
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "OCIRepository resources must only be from allowed organization domains."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/ocirepository-organization-domains

--- a/policies/FluxOCIRepositoryOrganizationDomains/policy.rego
+++ b/policies/FluxOCIRepositoryOrganizationDomains/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 domains := input.parameters.domains
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/FluxOCIRepositoryPatchAnnotation/metadata.yml
+++ b/policies/FluxOCIRepositoryPatchAnnotation/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: OCIRepository
   io.kubewarden.policy.title: ocirepository-patch-annotation
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "OCIRepository resources must have a patch annotation that matches the provider."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/ocirepository-patch-annotation

--- a/policies/FluxOCIRepositoryPatchAnnotation/policy.rego
+++ b/policies/FluxOCIRepositoryPatchAnnotation/policy.rego
@@ -3,6 +3,10 @@ package policy
 import future.keywords.in
 import data.k8s.matches
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 provider := input.parameters.provider
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/FluxResourceReconcileInterval/metadata.yml
+++ b/policies/FluxResourceReconcileInterval/metadata.yml
@@ -19,7 +19,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRelease, GitRepository, OCIRepository, Bucket, HelmChart, HelmRepository, Kustomization
   io.kubewarden.policy.title: resource-reconcile-interval
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "The reconcile interval of a Resource must be set between a lower and upper bound, lower_bound & upper_bound must be in seconds ."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/resource-reconcile-interval

--- a/policies/FluxResourceReconcileInterval/policy.rego
+++ b/policies/FluxResourceReconcileInterval/policy.rego
@@ -2,6 +2,12 @@ package policy
 
 import future.keywords.in
 
+default lower_bound := 1
+default upper_bound := 1000
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/FluxResourceWaiverList/metadata.yml
+++ b/policies/FluxResourceWaiverList/metadata.yml
@@ -19,7 +19,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: HelmRelease, GitRepository, OCIRepository, Bucket, HelmChart, HelmRepository, Kustomization
   io.kubewarden.policy.title: resource-suspend-waiver
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "Resource cannot be suspended unless it's on the waiver list."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/resource-suspend-waiver

--- a/policies/FluxResourceWaiverList/policy.rego
+++ b/policies/FluxResourceWaiverList/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/policies/IstioGatewayHosts/metadata.yml
+++ b/policies/IstioGatewayHosts/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Istio Gateway Approved Hosts
   io.artifacthub.resources: Gateway
   io.kubewarden.policy.title: istio-gateway-approved-hosts
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "### Istio Gateway Approved Hosts\nThis ensures you are only serving traffic for approved hostnames. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/istio-gateway-approved-hosts

--- a/policies/IstioGatewayHosts/policy.rego
+++ b/policies/IstioGatewayHosts/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 hostnames := input.parameters.hostnames
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/IstioNamespaceLabelInjection/metadata.yml
+++ b/policies/IstioNamespaceLabelInjection/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Istio Injected Namespaces
   io.artifacthub.resources: Namespace
   io.kubewarden.policy.title: istio-injected-namespaces
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "# Istio-Injected Namespaces\nSpecify namespaces you would like to be labeld with `istio-injected: enabled`. Namespaces with this label with automatically deploy a Istio sidecar with each pod. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/istio-injected-namespaces

--- a/policies/NamespaceLimitRangeMinMax/metadata.yml
+++ b/policies/NamespaceLimitRangeMinMax/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: soc2-type1
   io.artifacthub.resources: LimitRange
   io.kubewarden.policy.title: namespace-resources-limitrange
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: |
     When setting up default CPU and Memory values for your namespace, this policy will check if both requests and limits are set. This policy checks for the following:
 

--- a/policies/NamespaceLimitRangeMinMax/policy.rego
+++ b/policies/NamespaceLimitRangeMinMax/policy.rego
@@ -1,5 +1,7 @@
 package policy
 
+default namespace := "magalix"
+
 resource_type := input.parameters.resource_type
 resource_setting := input.parameters.resource_setting
 namespace := input.parameters.namespace

--- a/policies/NamespacePodQuota/metadata.yml
+++ b/policies/NamespacePodQuota/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Namespace Pod Quota
   io.artifacthub.resources: ResourceQuota
   io.kubewarden.policy.title: namespace-pod-quota
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "When using a pod quota ensure setting the proper value for the quantity of pods you wish to have in your namespace. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/namespace-pod-quota

--- a/policies/NamespacePodQuota/policy.rego
+++ b/policies/NamespacePodQuota/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default pod_quota := "2"
+default namespace := "magalix"
+
 pod_quota := input.parameters.pod_quota
 namespace := input.parameters.namespace
 

--- a/policies/NamespaceResourceQuotas/metadata.yml
+++ b/policies/NamespaceResourceQuotas/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: soc2-type1
   io.artifacthub.resources: ResourceQuota
   io.kubewarden.policy.title: resource-quota-setting-is-missing
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: |
     When creating resource quotas per namespace, ensure CPU and Memory requests and limits are set.
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>

--- a/policies/NamespaceResourceQuotas/policy.rego
+++ b/policies/NamespaceResourceQuotas/policy.rego
@@ -1,5 +1,7 @@
 package policy
 
+default namespace := "magalix"
+
 resource_type := input.parameters.resource_type
 namespace := input.parameters.namespace
 

--- a/policies/NetworkPolicyAllowEgressFromNamespaceToNamespace/metadata.yml
+++ b/policies/NetworkPolicyAllowEgressFromNamespaceToNamespace/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Network Allow Egress Traffic From Namespace To Another
   io.artifacthub.resources: NetworkPolicy
   io.kubewarden.policy.title: network-allow-egress-traffic-from-namespace-to-another
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "If you are using a CNI that allows for Network Policies, you can use this Policy to allow Egress traffic from one namespace to another.\n\nBy default, if no policies exist in a namespace, then all ingress and egress traffic is allowed to and from pods in that namespace. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/network-allow-egress-traffic-from-namespace-to-another

--- a/policies/NetworkPolicyAllowEgressFromNamespaceToNamespace/policy.rego
+++ b/policies/NetworkPolicyAllowEgressFromNamespaceToNamespace/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 src_namespace := input.parameters.src_namespace
 dst_namespace := input.parameters.dst_namespace
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/NetworkPolicyAllowIngressFromNamespaceToNamespace/metadata.yml
+++ b/policies/NetworkPolicyAllowIngressFromNamespaceToNamespace/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Network Allow Ingress Traffic From Namespace To Another
   io.artifacthub.resources: NetworkPolicy
   io.kubewarden.policy.title: network-allow-ingress-traffic-from-namespace-to-another
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "If you are using a CNI that allows for Network Policies, you can use this Policy to allow Ingress traffic from one namespace to another.\n\nBy default, if no policies exist in a namespace, then all ingress and egress traffic is allowed to and from pods in that namespace. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/network-allow-ingress-traffic-from-namespace-to-another

--- a/policies/NetworkPolicyAllowIngressFromNamespaceToNamespace/policy.rego
+++ b/policies/NetworkPolicyAllowIngressFromNamespaceToNamespace/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 src_namespace := input.parameters.src_namespace
 dst_namespace := input.parameters.dst_namespace
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/NetworkPolicyBlockIngressAllToNamespaceFromCIDR/metadata.yml
+++ b/policies/NetworkPolicyBlockIngressAllToNamespaceFromCIDR/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Network Block All Ingress Traffic To Namespace From CIDR Block
   io.artifacthub.resources: NetworkPolicy
   io.kubewarden.policy.title: network-block-all-ingress-traffic-to-namespace-from-cidr-block
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "If you are using a CNI that allows for Network Policies, you can use this Policy to block all Egress traffic from a specified namespace to a CIDR block of IP addresses. \n\nBy default, if no policies exist in a namespace, then all ingress and egress traffic is allowed to and from pods in that namespace. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/network-block-all-ingress-traffic-to-namespace-from-cidr-block

--- a/policies/NetworkPolicyBlockIngressAllToNamespaceFromCIDR/policy.rego
+++ b/policies/NetworkPolicyBlockIngressAllToNamespaceFromCIDR/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 namespace := input.parameters.namespace
 cidr := input.parameters.cidr
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/PersistentVolumeAccessModes/metadata.yml
+++ b/policies/PersistentVolumeAccessModes/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Persistent Volume Access Modes
   io.artifacthub.resources: PersistentVolume
   io.kubewarden.policy.title: persistent-volume-access-modes
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: |
     A PersistentVolume can be mounted on a host in any way supported by the resource provider. As shown in the table below, providers will have different capabilities and each PV's access modes are set to the specific modes supported by that particular volume. For example, NFS can support multiple read/write clients, but a specific NFS PV might be exported on the server as read-only. Each PV gets its own set of access modes describing that specific PV's capabilities.
 

--- a/policies/PersistentVolumeClaimSnapshot/metadata.yml
+++ b/policies/PersistentVolumeClaimSnapshot/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Persistent Volume Claim Snapshot
   io.artifacthub.resources: VolumeSnapshot
   io.kubewarden.policy.title: persistent-volume-claim-snapshot
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "This Policy checks for a PVC Snapshot. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/persistent-volume-claim-snapshot

--- a/policies/PersistentVolumeClaimSnapshot/policy.rego
+++ b/policies/PersistentVolumeClaimSnapshot/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 snapshot_class := input.parameters.snapshot_class
 pvc_name := input.parameters.pvc_name
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/RBACProhibitListOnSecrets/metadata.yml
+++ b/policies/RBACProhibitListOnSecrets/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Rbac Prohibit List On Secrets
   io.artifacthub.resources: Role, ClusterRole
   io.kubewarden.policy.title: rbac-prohibit-list-secrets
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "This Policy will violate if any RBAC ClusterRoles or Roles are designated with 'list' verb on 'secrets' resource.\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/rbac-prohibit-list-secrets

--- a/policies/RBACProhibitListOnSecrets/policy.rego
+++ b/policies/RBACProhibitListOnSecrets/policy.rego
@@ -1,5 +1,10 @@
 package policy
 
+default resource := "secrets"
+default verb := "list"
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 resource := input.parameters.resource
 verb := input.parameters.verb
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/RBACProhibitWatchOnSecrets/metadata.yml
+++ b/policies/RBACProhibitWatchOnSecrets/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Rbac Prohibit Watch On Secrets
   io.artifacthub.resources: Role, ClusterRole
   io.kubewarden.policy.title: rbac-prohibit-watch-secrets
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "This Policy will violate if any RBAC ClusterRoles or Roles are designated with 'watch' verb on 'secrets' resource.\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/rbac-prohibit-watch-secrets

--- a/policies/RBACProhibitWatchOnSecrets/policy.rego
+++ b/policies/RBACProhibitWatchOnSecrets/policy.rego
@@ -1,5 +1,10 @@
 package policy
 
+default resource := "secrets"
+default verb := "watch"
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 resource := input.parameters.resource
 verb := input.parameters.verb
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/RBACProhibitWildcardOnSecrets/metadata.yml
+++ b/policies/RBACProhibitWildcardOnSecrets/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Rbac Prohibit Wildcard On Secrets
   io.artifacthub.resources: Role, ClusterRole
   io.kubewarden.policy.title: rbac-prohibit-wildcard-secrets
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "This Policy will violate if any RBAC ClusterRoles or Roles are designated with 'wildcard' verb on 'secrets' resource.\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/rbac-prohibit-wildcard-secrets

--- a/policies/RBACProhibitWildcardOnSecrets/policy.rego
+++ b/policies/RBACProhibitWildcardOnSecrets/policy.rego
@@ -1,5 +1,10 @@
 package policy
 
+default resource := "secrets"
+default verb := "*"
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 resource := input.parameters.resource
 verb := input.parameters.verb
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/RBACProhibitWildcardsOnPolicyRuleResources/metadata.yml
+++ b/policies/RBACProhibitWildcardsOnPolicyRuleResources/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Rbac Prohibit Wildcards on Policy Rule Resources
   io.artifacthub.resources: Role, ClusterRole
   io.kubewarden.policy.title: rbac-prohibit-wildcards-policyrule-resources
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "This Policy prohibits various resources from being set with wildcards for Role or ClusterRole resources, except for the `cluster-admin` ClusterRole. It will check each resource specified for the verb specified. The wildcards will be checked in:\n\n### Resources\nIn the Kubernetes API, most resources are represented and accessed using a string representation of their object name, such as pods for a Pod. RBAC refers to resources using exactly the same name that appears in the URL for the relevant API endpoint. \n\n### Verbs\nAPI verbs like get, list, create, update, patch, watch, delete, and deletecollection are used for resource requests. \n\n### API Groups\nThe API Group being accessed (for resource requests only).\n\n### Non Resource URLs\nRequests to endpoints other than /api/v1/... or /apis/<group>/<version>/... are considered \"non-resource requests\", and use the lower-cased HTTP method of the request as the verb.\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/rbac-prohibit-wildcards-policyrule-resources

--- a/policies/RBACProhibitWildcardsOnPolicyRuleResources/policy.rego
+++ b/policies/RBACProhibitWildcardsOnPolicyRuleResources/policy.rego
@@ -1,5 +1,9 @@
 package policy
 
+default attributes := "resources"
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 attributes := input.parameters.attributes
 exclude_role_name := input.parameters.exclude_role_name
 exclude_label_key := input.parameters.exclude_label_key

--- a/policies/RBACProhibitWildcardsOnPolicyRuleVerbs/metadata.yml
+++ b/policies/RBACProhibitWildcardsOnPolicyRuleVerbs/metadata.yml
@@ -10,7 +10,7 @@ annotations:
   io.artifacthub.displayName: Rbac Prohibit Wildcards on Policy Rule Verbs
   io.artifacthub.resources: Role, ClusterRole
   io.kubewarden.policy.title: rbac-prohibit-wildcards-policyrule-verbs
-  io.kubewarden.policy.version: 1.0.0
+  io.kubewarden.policy.version: 1.0.1
   io.kubewarden.policy.description: "This Policy prohibits various resources from being set with wildcards for Role or ClusterRole resources, except for the `cluster-admin` ClusterRole. It will check each resource specified for the verb specified. The wildcards will be checked in:\n\n### Resources\nIn the Kubernetes API, most resources are represented and accessed using a string representation of their object name, such as pods for a Pod. RBAC refers to resources using exactly the same name that appears in the URL for the relevant API endpoint. \n\n### Verbs\nAPI verbs like get, list, create, update, patch, watch, delete, and deletecollection are used for resource requests. \n\n### API Groups\nThe API Group being accessed (for resource requests only).\n\n### Non Resource URLs\nRequests to endpoints other than /api/v1/... or /apis/<group>/<version>/... are considered \"non-resource requests\", and use the lower-cased HTTP method of the request as the verb.\n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/rbac-prohibit-wildcards-policyrule-verbs

--- a/policies/RBACProhibitWildcardsOnPolicyRuleVerbs/policy.rego
+++ b/policies/RBACProhibitWildcardsOnPolicyRuleVerbs/policy.rego
@@ -1,5 +1,9 @@
 package policy
 
+default attributes := "verbs"
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 attributes := input.parameters.attributes
 exclude_role_name := input.parameters.exclude_role_name
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerAffinityNode/policy.rego
+++ b/staging/ControllerAffinityNode/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 keys := input.parameters.keys
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerAffinityPods/policy.rego
+++ b/staging/ControllerAffinityPods/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 keys := input.parameters.keys
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerAntiAffinityPods/policy.rego
+++ b/staging/ControllerAntiAffinityPods/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 keys := input.parameters.keys
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerContainerAllowingPrivilegeEscalation/policy.rego
+++ b/staging/ControllerContainerAllowingPrivilegeEscalation/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := ["kube-system"]
+default allow_privilege_escalation := false
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 allow_privilege_escalation := input.parameters.allow_privilege_escalation
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerContainerBlockHostPath/policy.rego
+++ b/staging/ControllerContainerBlockHostPath/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default hostpath_key := "hostPath"
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 hostpath_key := input.parameters.hostpath_key
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerContainerBlockPortsRange/policy.rego
+++ b/staging/ControllerContainerBlockPortsRange/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default target_port := 1024
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 target_port := input.parameters.target_port
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerContainerEnforceEnvVar/policy.rego
+++ b/staging/ControllerContainerEnforceEnvVar/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name := input.parameters.envvar_name
 app_name := input.parameters.app_name
 exclude_namespaces := input.parameters.exclude_namespaces

--- a/staging/ControllerContainerLinuxCapabilities/policy.rego
+++ b/staging/ControllerContainerLinuxCapabilities/policy.rego
@@ -2,6 +2,8 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/ControllerContainerProhibitEnvVar/policy.rego
+++ b/staging/ControllerContainerProhibitEnvVar/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = input.parameters.envvar_name
 app_name = input.parameters.app_name
 exclude_namespaces := input.parameters.exclude_namespaces

--- a/staging/ControllerContainerRunningPrivilegedMode/policy.rego
+++ b/staging/ControllerContainerRunningPrivilegedMode/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default privilege := false
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 privilege := input.parameters.privilege
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerContainerServiceAccountTokenAutomount/policy.rego
+++ b/staging/ControllerContainerServiceAccountTokenAutomount/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default automount_token := false
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 automount_token := input.parameters.automount_token
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerContainerUsingHostPort/policy.rego
+++ b/staging/ControllerContainerUsingHostPort/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default host_port := "hostPort"
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 host_port := input.parameters.host_port
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerDockerSocketMount/policy.rego
+++ b/staging/ControllerDockerSocketMount/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default docker_sock := "docker.sock"
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 docker_socket_name := input.parameters.docker_socket
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerImageApprovedRegistry/policy.rego
+++ b/staging/ControllerImageApprovedRegistry/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 my_registries := input.parameters.registries
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerImagePullPolicy/policy.rego
+++ b/staging/ControllerImagePullPolicy/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default policy := "Always"
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 policy := input.parameters.policy
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerImageTag/policy.rego
+++ b/staging/ControllerImageTag/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default image_tag := "latest"
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 image_tag := input.parameters.image_tag
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerMinimumReplicaCount/policy.rego
+++ b/staging/ControllerMinimumReplicaCount/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default replica_count := 2
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 min_replica_count := input.parameters.replica_count
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerMissingLivenessProbe/policy.rego
+++ b/staging/ControllerMissingLivenessProbe/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/ControllerMissingMatchLabelKey/policy.rego
+++ b/staging/ControllerMissingMatchLabelKey/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 label := input.parameters.label
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerMissingReadinessProbe/policy.rego
+++ b/staging/ControllerMissingReadinessProbe/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/ControllerMissingStartupProbe/policy.rego
+++ b/staging/ControllerMissingStartupProbe/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/ControllerProbesCustom/policy.rego
+++ b/staging/ControllerProbesCustom/policy.rego
@@ -2,6 +2,13 @@ package policy
 
 import future.keywords.in
 
+default command := []
+default path := ""
+default port := 0
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 probe_type := input.parameters.probe_type
 command := input.parameters.command
 path := input.parameters.path

--- a/staging/ControllerProbesNamedPort/policy.rego
+++ b/staging/ControllerProbesNamedPort/policy.rego
@@ -1,5 +1,7 @@
 package policy
 
+default probe := "livenessProbe"
+
 healthcheck_name := "healthcheck"
 
 

--- a/staging/ControllerReadOnlyFileSystem/policy.rego
+++ b/staging/ControllerReadOnlyFileSystem/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default read_only := true
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 read_only = input.parameters.read_only
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerResourcesMaxCPULimits/policy.rego
+++ b/staging/ControllerResourcesMaxCPULimits/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 max_size := input.parameters.size
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerResourcesMaxCPURequests/policy.rego
+++ b/staging/ControllerResourcesMaxCPURequests/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 max_size := input.parameters.size
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerResourcesMaxMemoryLimits/policy.rego
+++ b/staging/ControllerResourcesMaxMemoryLimits/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 max_size := input.parameters.size
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerResourcesMaxMemoryRequests/policy.rego
+++ b/staging/ControllerResourcesMaxMemoryRequests/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 max_size := input.parameters.size
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerResourcesMinCPULimits/policy.rego
+++ b/staging/ControllerResourcesMinCPULimits/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 min_size := input.parameters.size
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerResourcesMinCPURequests/policy.rego
+++ b/staging/ControllerResourcesMinCPURequests/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 min_size := input.parameters.size
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerResourcesMinMemoryLimits/policy.rego
+++ b/staging/ControllerResourcesMinMemoryLimits/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 min_size := input.parameters.size
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerResourcesMinMemoryRequests/policy.rego
+++ b/staging/ControllerResourcesMinMemoryRequests/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 min_size := input.parameters.size
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerRestartPolicy/policy.rego
+++ b/staging/ControllerRestartPolicy/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default restart_policy := "Always"
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 restart_policy := input.parameters.restart_policy
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerSeccompRuntimeDefault/policy.rego
+++ b/staging/ControllerSeccompRuntimeDefault/policy.rego
@@ -2,6 +2,12 @@ package policy
 
 import future.keywords.in
 
+default seccomp_annotation := "runtime/default"
+default seccomp_type := "RuntimeDefault"
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 seccomp_annotation := input.parameters.seccomp_annotation
 seccomp_type := input.parameters.seccomp_type
 exclude_namespaces := input.parameters.exclude_namespaces

--- a/staging/ControllerShareHostIPC/policy.rego
+++ b/staging/ControllerShareHostIPC/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default resource_enabled := false
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 resource_enabled := input.parameters.resource_enabled
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerShareHostNetwork/policy.rego
+++ b/staging/ControllerShareHostNetwork/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default resource_enabled := false
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 resource_enabled := input.parameters.resource_enabled
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerShareHostPID/policy.rego
+++ b/staging/ControllerShareHostPID/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default resource_enabled := false
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 resource_enabled := input.parameters.resource_enabled
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerShareProcessNamespace/policy.rego
+++ b/staging/ControllerShareProcessNamespace/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default resource_enabled := false
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 resource_enabled := input.parameters.resource_enabled
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerSpecGeneric/policy.rego
+++ b/staging/ControllerSpecGeneric/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 key := input.parameters.controller_spec_key
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerSpecTemplateLabels/policy.rego
+++ b/staging/ControllerSpecTemplateLabels/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 label := input.parameters.label
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ControllerTolerations/policy.rego
+++ b/staging/ControllerTolerations/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default toleration_key := "node-role.kubernetes.io/master"
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 toleration_key := input.parameters.toleration_key
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/InfluxDBEnforceAdminTokenEnvVar/policy.rego
+++ b/staging/InfluxDBEnforceAdminTokenEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "DOCKER_INFLUXDB_INIT_ADMIN_TOKEN"
 app_name = "influxdb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/InfluxDBEnforceBucketEnvVar/policy.rego
+++ b/staging/InfluxDBEnforceBucketEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "DOCKER_INFLUXDB_INIT_BUCKET"
 app_name = "influxdb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/InfluxDBEnforceOrgEnvVar/policy.rego
+++ b/staging/InfluxDBEnforceOrgEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "DOCKER_INFLUXDB_INIT_ORG"
 app_name = "influxdb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/InfluxDBEnforcePasswordEnvVar/policy.rego
+++ b/staging/InfluxDBEnforcePasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "DOCKER_INFLUXDB_INIT_PASSWORD"
 app_name = "influxdb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/InfluxDBEnforceRetentionEnvVar/policy.rego
+++ b/staging/InfluxDBEnforceRetentionEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "DOCKER_INFLUXDB_INIT_RETENTION"
 app_name = "influxdb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/InfluxDBEnforceUsernameEnvVar/policy.rego
+++ b/staging/InfluxDBEnforceUsernameEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "DOCKER_INFLUXDB_INIT_USERNAME"
 app_name = "influxdb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/IngressClass/policy.rego
+++ b/staging/IngressClass/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 annotation  := input.parameters.annotation
 class := input.parameters.class
 exclude_namespaces := input.parameters.exclude_namespaces

--- a/staging/IngressHostname/policy.rego
+++ b/staging/IngressHostname/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 hostnames := input.parameters.hostnames
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/KubernetesProhibitKind/policy.rego
+++ b/staging/KubernetesProhibitKind/policy.rego
@@ -1,5 +1,7 @@
 package policy
 
+default kind := "Pods"
+
 kind := input.parameters.kind
 
 violation[result] {

--- a/staging/MYSQLEnforceDatabaseEnvVar/policy.rego
+++ b/staging/MYSQLEnforceDatabaseEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_DATABASE"
 app_name = "mysql"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MYSQLEnforceOnetimePasswordEnvVar/policy.rego
+++ b/staging/MYSQLEnforceOnetimePasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_ONETIME_PASSWORD"
 app_name = "mysql"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MYSQLEnforcePasswordEnvVar/policy.rego
+++ b/staging/MYSQLEnforcePasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_PASSWORD"
 app_name = "mysql"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MYSQLEnforceRandomRootPasswordEnvVar/policy.rego
+++ b/staging/MYSQLEnforceRandomRootPasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_RANDOM_ROOT_PASSWORD"
 app_name = "mysql"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MYSQLEnforceRootPasswordEnvVar/policy.rego
+++ b/staging/MYSQLEnforceRootPasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_ROOT_PASSWORD"
 app_name = "mysql"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MYSQLEnforceSkipTzinfoEnvVar/policy.rego
+++ b/staging/MYSQLEnforceSkipTzinfoEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_INITDB_SKIP_TZINFO"
 app_name = "mysql"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MYSQLEnforceUserEnvVar/policy.rego
+++ b/staging/MYSQLEnforceUserEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_USER"
 app_name = "mysql"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MYSQLProhibitEmptyPasswordEnvVar/policy.rego
+++ b/staging/MYSQLProhibitEmptyPasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_ALLOW_EMPTY_PASSWORD"
 app_name = "mysql"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBEnforceDatabaseEnvVar/policy.rego
+++ b/staging/MariaDBEnforceDatabaseEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MARIADB_DATABASE"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBEnforceMysqlDatabaseEnvVar/policy.rego
+++ b/staging/MariaDBEnforceMysqlDatabaseEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_DATABASE"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBEnforceMysqlPasswordEnvVar/policy.rego
+++ b/staging/MariaDBEnforceMysqlPasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_PASSWORD"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBEnforceMysqlRandomRootPasswordEnvVar/policy.rego
+++ b/staging/MariaDBEnforceMysqlRandomRootPasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_RANDOM_ROOT_PASSWORD"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBEnforceMysqlRootPasswordEnvVar/policy.rego
+++ b/staging/MariaDBEnforceMysqlRootPasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_ROOT_PASSWORD"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBEnforceMysqlSkipTzinfoEnvVar/policy.rego
+++ b/staging/MariaDBEnforceMysqlSkipTzinfoEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_INITDB_SKIP_TZINFO"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBEnforceMysqlUserEnvVar/policy.rego
+++ b/staging/MariaDBEnforceMysqlUserEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_USER"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBEnforcePasswordEnvVar/policy.rego
+++ b/staging/MariaDBEnforcePasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MARIADB_PASSWORD"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBEnforceRandomRootPasswordEnvVar/policy.rego
+++ b/staging/MariaDBEnforceRandomRootPasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MARIADB_RANDOM_ROOT_PASSWORD"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBEnforceRootPasswordEnvVar/policy.rego
+++ b/staging/MariaDBEnforceRootPasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MARIADB_ROOT_PASSWORD"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBEnforceSkipTzinfoEnvVar/policy.rego
+++ b/staging/MariaDBEnforceSkipTzinfoEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MARIADB_INITDB_SKIP_TZINFO"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBEnforceUserEnvVar/policy.rego
+++ b/staging/MariaDBEnforceUserEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MARIADB_USER"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBProhibitEmptyPasswordEnvVar/policy.rego
+++ b/staging/MariaDBProhibitEmptyPasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MARIADB_ALLOW_EMPTY_PASSWORD"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MariaDBProhibitMysqlEmptyPasswordEnvVar/policy.rego
+++ b/staging/MariaDBProhibitMysqlEmptyPasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MYSQL_ALLOW_EMPTY_PASSWORD"
 app_name = "mariadb"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoDBEnforceDatabaseEnvVar/policy.rego
+++ b/staging/MongoDBEnforceDatabaseEnvVar/policy.rego
@@ -2,9 +2,14 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MONGO_INITDB_DATABASE"
 app_name = "mongo"
 exclude_app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoDBEnforceRootPasswordEnvVar/policy.rego
+++ b/staging/MongoDBEnforceRootPasswordEnvVar/policy.rego
@@ -2,9 +2,14 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MONGO_INITDB_ROOT_PASSWORD"
 app_name = "mongo"
 exclude_app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoDBEnforceRootPasswordFileEnvVar/policy.rego
+++ b/staging/MongoDBEnforceRootPasswordFileEnvVar/policy.rego
@@ -2,9 +2,14 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MONGO_INITDB_ROOT_PASSWORD_FILE"
 app_name = "mongo"
 exclude_app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoDBEnforceRootUsernameEnvVar/policy.rego
+++ b/staging/MongoDBEnforceRootUsernameEnvVar/policy.rego
@@ -2,9 +2,14 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MONGO_INITDB_ROOT_USERNAME"
 app_name = "mongo"
 exclude_app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoDBEnforceRootUsernameFileEnvVar/policy.rego
+++ b/staging/MongoDBEnforceRootUsernameFileEnvVar/policy.rego
@@ -2,9 +2,14 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "MONGO_INITDB_ROOT_USERNAME_FILE"
 app_name = "mongo"
 exclude_app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceAdminPasswordEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceAdminPasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_MONGODB_ADMINPASSWORD"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceAdminUsernameEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceAdminUsernameEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_MONGODB_ADMINUSERNAME"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceAuthPasswordEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceAuthPasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_BASICAUTH_PASSWORD"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceAuthUsernameEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceAuthUsernameEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_BASICAUTH_USERNAME"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceBaseURLEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceBaseURLEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_SITE_BASEURL"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceCookieSecretEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceCookieSecretEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_SITE_COOKIESECRET"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceEditorThemeEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceEditorThemeEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_OPTIONS_EDITORTHEME"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceEnableAdminEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceEnableAdminEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_MONGODB_ENABLE_ADMIN"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceMongoPortEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceMongoPortEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_MONGODB_PORT"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceMongoServerEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceMongoServerEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_MONGODB_SERVER"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceRequestSizeEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceRequestSizeEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_REQUEST_SIZE"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceSSLCrtPathEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceSSLCrtPathEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_SITE_SSL_CRT_PATH"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceSSLEnabledEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceSSLEnabledEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_SITE_SSL_ENABLED"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceSSLKeyPathEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceSSLKeyPathEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_SITE_SSL_KEY_PATH"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/MongoExpressEnforceSessionSecretEnvVar/policy.rego
+++ b/staging/MongoExpressEnforceSessionSecretEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "ME_CONFIG_SITE_SESSIONSECRET"
 app_name = "mongo-express"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/NamespaceProhibitName/policy.rego
+++ b/staging/NamespaceProhibitName/policy.rego
@@ -1,5 +1,7 @@
 package policy
 
+default namespace_name := "kube-"
+
 namespace_name := input.parameters.namespace_name
 
 violation[result] {

--- a/staging/NetworkPolicyAllowEgressAllFromNamespace/policy.rego
+++ b/staging/NetworkPolicyAllowEgressAllFromNamespace/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 namespace := input.parameters.namespace
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/NetworkPolicyAllowEgressAllFromNamespaceToCIDR/policy.rego
+++ b/staging/NetworkPolicyAllowEgressAllFromNamespaceToCIDR/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 namespace := input.parameters.namespace
 cidr := input.parameters.cidr
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/NetworkPolicyAllowEgressDNSFromNamespace/policy.rego
+++ b/staging/NetworkPolicyAllowEgressDNSFromNamespace/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 namespace := input.parameters.namespace
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/NetworkPolicyAllowIngressAllToNamespace/policy.rego
+++ b/staging/NetworkPolicyAllowIngressAllToNamespace/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 namespace := input.parameters.namespace
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/NetworkPolicyAllowIngressAllToNamespaceFromCIDR/policy.rego
+++ b/staging/NetworkPolicyAllowIngressAllToNamespaceFromCIDR/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 namespace := input.parameters.namespace
 cidr := input.parameters.cidr
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/NetworkPolicyBlockEgressAllFromNamespace/policy.rego
+++ b/staging/NetworkPolicyBlockEgressAllFromNamespace/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 namespace := input.parameters.namespace
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/NetworkPolicyBlockEgressAllFromNamespaceToCIDR/policy.rego
+++ b/staging/NetworkPolicyBlockEgressAllFromNamespaceToCIDR/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 namespace := input.parameters.namespace
 blocked_cidr := input.parameters.blocked_cidr
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/NetworkPolicyBlockIngressAllToNamespace/policy.rego
+++ b/staging/NetworkPolicyBlockIngressAllToNamespace/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 namespace := input.parameters.namespace
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/NetworkPolicyDefaultRulesBlockAllEgress/policy.rego
+++ b/staging/NetworkPolicyDefaultRulesBlockAllEgress/policy.rego
@@ -2,7 +2,12 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 policy_type := "Egress"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/NetworkPolicyDefaultRulesBlockAllIngress/policy.rego
+++ b/staging/NetworkPolicyDefaultRulesBlockAllIngress/policy.rego
@@ -2,7 +2,12 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 policy_type := "Ingress"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/NodeCustomLabel/policy.rego
+++ b/staging/NodeCustomLabel/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 key := input.parameters.key
 value := input.parameters.value
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/NodeMissingLabel/policy.rego
+++ b/staging/NodeMissingLabel/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 label := input.parameters.node_label
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/NodeOSVersion/policy.rego
+++ b/staging/NodeOSVersion/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 desired_os := input.parameters.os
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PersistentVolumeClaimMaxSize/policy.rego
+++ b/staging/PersistentVolumeClaimMaxSize/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 max_size := input.parameters.size
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PersistentVolumeMaxSize/policy.rego
+++ b/staging/PersistentVolumeMaxSize/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 max_size := input.parameters.size
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PersistentVolumeReclaimPolicy/policy.rego
+++ b/staging/PersistentVolumeReclaimPolicy/policy.rego
@@ -1,5 +1,9 @@
 package policy
 
+default pv_policy := "Retain"
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 policy := input.parameters.pv_policy
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PostgresEnforceAuthMethodEnvVar/policy.rego
+++ b/staging/PostgresEnforceAuthMethodEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "POSTGRES_HOST_AUTH_METHOD"
 app_name = "postgres"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PostgresEnforceDBEnvVar/policy.rego
+++ b/staging/PostgresEnforceDBEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "POSTGRES_DB"
 app_name = "postgres"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PostgresEnforceInitDBArgsEnvVar/policy.rego
+++ b/staging/PostgresEnforceInitDBArgsEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "POSTGRES_INITDB_ARGS"
 app_name = "postgres"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PostgresEnforceInitDBWaldirEnvVar/policy.rego
+++ b/staging/PostgresEnforceInitDBWaldirEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "POSTGRES_INITDB_WALDIR"
 app_name = "postgres"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PostgresEnforcePGDataEnvVar/policy.rego
+++ b/staging/PostgresEnforcePGDataEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "PGDATA"
 app_name = "postgres"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PostgresEnforcePasswordEnvVar/policy.rego
+++ b/staging/PostgresEnforcePasswordEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "POSTGRES_PASSWORD"
 app_name = "postgres"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PostgresEnforceUserEnvVar/policy.rego
+++ b/staging/PostgresEnforceUserEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "POSTGRES_USER"
 app_name = "postgres"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PrometheusAnnotationKey/policy.rego
+++ b/staging/PrometheusAnnotationKey/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 annotation := input.parameters.prometheus_annotation_key
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/PrometheusAnnotationValue/policy.rego
+++ b/staging/PrometheusAnnotationValue/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 annotation_key := input.parameters.prometheus_annotation_key
 annotation_value := input.parameters.prometheus_annotation_value
 exclude_namespaces := input.parameters.exclude_namespaces

--- a/staging/PrometheusRBACClusterRole/policy.rego
+++ b/staging/PrometheusRBACClusterRole/policy.rego
@@ -1,5 +1,9 @@
 package policy
 
+default prometheus_verb := "put"
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 verb := input.parameters.prometheus_verb
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PrometheusRBACClusterRoleBinding/policy.rego
+++ b/staging/PrometheusRBACClusterRoleBinding/policy.rego
@@ -1,5 +1,9 @@
 package policy
 
+default prometheus_subject_name := "prometheus"
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 subject_name := input.parameters.prometheus_subject_name
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/PrometheusServiceAnnontationKey/policy.rego
+++ b/staging/PrometheusServiceAnnontationKey/policy.rego
@@ -2,6 +2,10 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 annotation := input.parameters.prometheus_service_annotation
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/RBACClusterRoleClusterAdmin/policy.rego
+++ b/staging/RBACClusterRoleClusterAdmin/policy.rego
@@ -1,5 +1,10 @@
 package policy
 
+default subjects_name := "system:masters"
+default subjects_kind := "Group"
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 subjects_kind := input.parameters.subjects_kind
 subjects_name := input.parameters.subjects_name
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/RBACProhibitEditingConfigMaps/policy.rego
+++ b/staging/RBACProhibitEditingConfigMaps/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 resource_name := input.parameters.resource_name
 verb := input.parameters.verb
 namespace := input.parameters.namespace

--- a/staging/RBACProhibitVerbsOnResources/policy.rego
+++ b/staging/RBACProhibitVerbsOnResources/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 resource := input.parameters.resource
 verb := input.parameters.verb
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/RBACProhibitWildcards/policy.rego
+++ b/staging/RBACProhibitWildcards/policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 attributes := input.parameters.attributes
 exclude_role_name := input.parameters.exclude_role_name
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/RabbitMQEnforceConfigFileEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceConfigFileEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_CONFIG_FILE"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceDefaultPassEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceDefaultPassEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_DEFAULT_PASS"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceDefaultUserEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceDefaultUserEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_DEFAULT_USER"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceDefaultVHostEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceDefaultVHostEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_DEFAULT_VHOST"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceERLArgsEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceERLArgsEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceEnabledPluginsEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceEnabledPluginsEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_ENABLED_PLUGINS_FILE"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceGeneratedConfigDirEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceGeneratedConfigDirEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_GENERATED_CONFIG_DIR"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceLogBaseEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceLogBaseEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_LOG_BASE"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceLogsEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceLogsEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_LOGS"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceMnesiaBaseEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceMnesiaBaseEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_MNESIA_BASE"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceMnesiaDirEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceMnesiaDirEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_MNESIA_DIR"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforcePidFileEnvVar/policy.rego
+++ b/staging/RabbitMQEnforcePidFileEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_PID_FILE"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforcePluginsDirEnvVar/policy.rego
+++ b/staging/RabbitMQEnforcePluginsDirEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_PLUGINS_DIR"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforcePluginsExpandDirEnvVar/policy.rego
+++ b/staging/RabbitMQEnforcePluginsExpandDirEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_PLUGINS_EXPAND_DIR"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceSSLCACertFileEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceSSLCACertFileEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_SSL_CACERTFILE"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceSSLCertFileEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceSSLCertFileEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_SSL_CERTFILE"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceSSLDepthEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceSSLDepthEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_SSL_DEPTH"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceSSLFailNoPeerEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceSSLFailNoPeerEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceSSLKeyFileEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceSSLKeyFileEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_SSL_KEYFILE"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceSSLVerifyEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceSSLVerifyEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_SSL_VERIFY"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceSchemaDirEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceSchemaDirEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_SCHEMA_DIR"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/RabbitMQEnforceVMMemoryEnvVar/policy.rego
+++ b/staging/RabbitMQEnforceVMMemoryEnvVar/policy.rego
@@ -2,8 +2,13 @@ package policy
 
 import future.keywords.in
 
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 env_name = "RABBITMQ_VM_MEMORY_HIGH_WATERMARK"
 app_name = "rabbitmq"
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value

--- a/staging/ServiceAccountDisableTokenAutomount/policy.rego
+++ b/staging/ServiceAccountDisableTokenAutomount/policy.rego
@@ -1,5 +1,10 @@
 package policy
 
+default automount := false
+default namespace := "default"
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 automount_value = input.parameters.automount
 namespace = input.parameters.namespace
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ServiceProhibitPortsRange/policy.rego
+++ b/staging/ServiceProhibitPortsRange/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default target_port := 1024
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 target_port := input.parameters.target_port
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ServiceProhibitType/policy.rego
+++ b/staging/ServiceProhibitType/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default type := "NodePort"
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 type := input.parameters.type
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key

--- a/staging/ServiceRestrictProtocols/policy.rego
+++ b/staging/ServiceRestrictProtocols/policy.rego
@@ -2,6 +2,11 @@ package policy
 
 import future.keywords.in
 
+default protocols := "HTTPS"
+default exclude_namespaces := []
+default exclude_label_key := ""
+default exclude_label_value := ""
+
 service_protocol := input.parameters.protocols
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key


### PR DESCRIPTION
## Description
Fixes: #23 

Adds default directives based on the `spec.parameters` schema from `policy.yaml`. For each non-required parameter, assigns the default type, either the specified default value from the parameters spec or the type's empty value.
