### PR TITLE
fix(metadata-missing-label-and-value): fix no labels violation

### DIFF
--- a/policies/ControllerMissingLabelValue/policy.rego
+++ b/policies/ControllerMissingLabelValue/policy.rego
@@ -8,30 +8,43 @@ default exclude_label_value := ""
 
 label := input.parameters.label
 value := input.parameters.value
+
 exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value
 
+violation[result] {
+	isExcludedNamespace == false
+	not exclude_label_value == controller_input.metadata.labels[exclude_label_key]
+	# Filter the type of entity before moving on since this shouldn't apply to all entities
+	contains_kind(controller_input.kind, {"StatefulSet", "DaemonSet", "Deployment", "Job"})
+	not value == controller_input.metadata.labels[label]
+	result = {
+		"issue_detected": true,
+		"msg": sprintf("The key:value pair '%v:%v' was not found; detected labels: '%v", [label, value, controller_input.metadata.labels]),
+		"violating_key": sprintf("metadata.labels.%v", [label]),
+		"recommended_value": value,
+	}
+}
 
 violation[result] {
-  isExcludedNamespace == false
-  not exclude_label_value == controller_input.metadata.labels[exclude_label_key]
-  # Filter the type of entity before moving on since this shouldn't apply to all entities
-  contains_kind(controller_input.kind, {"StatefulSet" , "DaemonSet", "Deployment", "Job"})
-  not value == controller_input.metadata.labels[label]
-  result = {
-    "issue_detected": true,
-    "msg": sprintf("The key:value pair '%v:%v' was not found; detected labels: '%v", [label, value, controller_input.metadata.labels]),
-    "violating_key": sprintf("metadata.labels.%v", [label]),
-    "recommended_value": value
-  }
+	isExcludedNamespace == false
+	contains_kind(controller_input.kind, {"StatefulSet", "DaemonSet", "Deployment", "Job"})
+	# Check for missing labels object
+	not controller_input.metadata.labels
+	result = {
+		"issue_detected": true,
+		"msg": sprintf("The resource has no labels. Required label '%v:%v' not found.", [label, value]),
+		"violating_key": "metadata.labels",
+		"recommended_value": sprintf("{%v: %v}", [label, value]),
+	}
 }
 
 # Controller input
 controller_input = input.review.object
 
 contains_kind(kind, kinds) {
-  kinds[_] = kind
+	kinds[_] = kind
 }
 
 isExcludedNamespace = true {

--- a/policies/ControllerMissingLabelValue/tests/no_labels.rego
+++ b/policies/ControllerMissingLabelValue/tests/no_labels.rego
@@ -1,0 +1,60 @@
+package policy
+
+test_no_labels {
+	testcase = {
+		"parameters": {
+			"label": "owner",
+			"value": "tony2",
+			"exclude_namespace": "",
+			"exclude_label_key": "",
+			"exclude_label_value": "",
+		},
+		"review": {"object": {
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
+			"metadata": {"name": "demoservice"},
+			"spec": {
+				"replicas": 1,
+				"selector": {"matchLabels": {"app": "demoservice"}},
+				"template": {
+					"metadata": {"labels": {"app": "demoservice"}},
+					"spec": {
+						"securityContext": {
+							"runAsUser": 0,
+							"runAsGroup": 1000,
+							"fsGroup": 1000,
+							"runAsNonRoot": false,
+						},
+						"containers": [{
+							"name": "demoservice",
+							"command": [
+								"node",
+								"app.js",
+							],
+							"image": "airwavetechio/demoservice:v0.0.2",
+							"env": [{
+								"name": "PORT",
+								"value": "5001",
+							}],
+							"ports": [{
+								"containerPort": 5001,
+								"name": "liveness-port",
+							}],
+							"securityContext": {
+								"privileged": true,
+								"allowPrivilegeEscalation": true,
+								"readOnlyRootFilesystem": false,
+								"runAsUser": 1000,
+								"runAsGroup": 1000,
+								"runAsNonRoot": true,
+								"capabilities": {"add": ["SYS_ADMIN"]},
+							},
+						}],
+					},
+				},
+			},
+		}},
+	}
+
+	count(violation) == 1 with input as testcase
+}


### PR DESCRIPTION
## Description

This change introduces a new violation to ensure that resources without any labels are no longer accepted by the policy, addressing the previous behavior where such resources were always allowed.

## Tests

Adds a test case.

Fixes #31

