### PR TITLE
Add UI questions notification.

### DIFF
--- a/policies/ControllerAffinityNodeSelector/questions-ui.yml
+++ b/policies/ControllerAffinityNodeSelector/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/ControllerContainerBlockSSHPort/questions-ui.yml
+++ b/policies/ControllerContainerBlockSSHPort/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/ControllerContainerRunningAsUser/questions-ui.yml
+++ b/policies/ControllerContainerRunningAsUser/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/ControllerImageName/questions-ui.yml
+++ b/policies/ControllerImageName/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/ControllerMissingLabelValue/questions-ui.yml
+++ b/policies/ControllerMissingLabelValue/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/ControllerProhibitNamespace/questions-ui.yml
+++ b/policies/ControllerProhibitNamespace/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxBucketApprovedRegion/questions-ui.yml
+++ b/policies/FluxBucketApprovedRegion/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxBucketEndpointDomain/questions-ui.yml
+++ b/policies/FluxBucketEndpointDomain/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxGitRepositoryIgonreSuffixes/questions-ui.yml
+++ b/policies/FluxGitRepositoryIgonreSuffixes/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxGitRepositoryOrganizationDomains/questions-ui.yml
+++ b/policies/FluxGitRepositoryOrganizationDomains/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxGitRepositorySpecificBranch/questions-ui.yml
+++ b/policies/FluxGitRepositorySpecificBranch/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxGitRepositoryUntrustedDomains/questions-ui.yml
+++ b/policies/FluxGitRepositoryUntrustedDomains/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxHelmReleaseMaxHistory/questions-ui.yml
+++ b/policies/FluxHelmReleaseMaxHistory/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxHelmReleaseRemediationRetries/questions-ui.yml
+++ b/policies/FluxHelmReleaseRemediationRetries/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxHelmReleaseServiceAccountName/questions-ui.yml
+++ b/policies/FluxHelmReleaseServiceAccountName/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxHelmReleaseStorageNamespace/questions-ui.yml
+++ b/policies/FluxHelmReleaseStorageNamespace/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxHelmReleaseTargetNameSpace/questions-ui.yml
+++ b/policies/FluxHelmReleaseTargetNameSpace/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxHelmReleaseValuesFromConfigMaps/questions-ui.yml
+++ b/policies/FluxHelmReleaseValuesFromConfigMaps/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxHelmRepositoryURL/questions-ui.yml
+++ b/policies/FluxHelmRepositoryURL/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxKustomizationDecryptionProvider/questions-ui.yml
+++ b/policies/FluxKustomizationDecryptionProvider/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxKustomizationPaths/questions-ui.yml
+++ b/policies/FluxKustomizationPaths/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxKustomizationTargetNamespace/questions-ui.yml
+++ b/policies/FluxKustomizationTargetNamespace/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxKustomizeImagesRequirement/questions-ui.yml
+++ b/policies/FluxKustomizeImagesRequirement/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxKustomizePatchesRequirement/questions-ui.yml
+++ b/policies/FluxKustomizePatchesRequirement/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxKustomizePrune/questions-ui.yml
+++ b/policies/FluxKustomizePrune/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxOCIRepositoryIgonreSuffixes/questions-ui.yml
+++ b/policies/FluxOCIRepositoryIgonreSuffixes/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxOCIRepositoryLayerSelector/questions-ui.yml
+++ b/policies/FluxOCIRepositoryLayerSelector/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxOCIRepositoryOrganizationDomains/questions-ui.yml
+++ b/policies/FluxOCIRepositoryOrganizationDomains/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxOCIRepositoryPatchAnnotation/questions-ui.yml
+++ b/policies/FluxOCIRepositoryPatchAnnotation/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxResourceReconcileInterval/questions-ui.yml
+++ b/policies/FluxResourceReconcileInterval/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/FluxResourceWaiverList/questions-ui.yml
+++ b/policies/FluxResourceWaiverList/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/IstioGatewayHosts/questions-ui.yml
+++ b/policies/IstioGatewayHosts/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/IstioNamespaceLabelInjection/questions-ui.yml
+++ b/policies/IstioNamespaceLabelInjection/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/NamespaceLimitRangeMinMax/questions-ui.yml
+++ b/policies/NamespaceLimitRangeMinMax/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/NamespacePodQuota/questions-ui.yml
+++ b/policies/NamespacePodQuota/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/NamespaceResourceQuotas/questions-ui.yml
+++ b/policies/NamespaceResourceQuotas/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/NetworkPolicyAllowEgressFromNamespaceToNamespace/questions-ui.yml
+++ b/policies/NetworkPolicyAllowEgressFromNamespaceToNamespace/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/NetworkPolicyAllowIngressFromNamespaceToNamespace/questions-ui.yml
+++ b/policies/NetworkPolicyAllowIngressFromNamespaceToNamespace/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/NetworkPolicyBlockIngressAllToNamespaceFromCIDR/questions-ui.yml
+++ b/policies/NetworkPolicyBlockIngressAllToNamespaceFromCIDR/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/PersistentVolumeAccessModes/questions-ui.yml
+++ b/policies/PersistentVolumeAccessModes/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/PersistentVolumeClaimSnapshot/questions-ui.yml
+++ b/policies/PersistentVolumeClaimSnapshot/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/RBACProhibitListOnSecrets/questions-ui.yml
+++ b/policies/RBACProhibitListOnSecrets/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/RBACProhibitWatchOnSecrets/questions-ui.yml
+++ b/policies/RBACProhibitWatchOnSecrets/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/RBACProhibitWildcardOnSecrets/questions-ui.yml
+++ b/policies/RBACProhibitWildcardOnSecrets/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/RBACProhibitWildcardsOnPolicyRuleResources/questions-ui.yml
+++ b/policies/RBACProhibitWildcardsOnPolicyRuleResources/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/policies/RBACProhibitWildcardsOnPolicyRuleVerbs/questions-ui.yml
+++ b/policies/RBACProhibitWildcardsOnPolicyRuleVerbs/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerAffinityNode/questions-ui.yml
+++ b/staging/ControllerAffinityNode/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerAffinityPods/questions-ui.yml
+++ b/staging/ControllerAffinityPods/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerAntiAffinityPods/questions-ui.yml
+++ b/staging/ControllerAntiAffinityPods/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerContainerAllowingPrivilegeEscalation/questions-ui.yml
+++ b/staging/ControllerContainerAllowingPrivilegeEscalation/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerContainerBlockHostPath/questions-ui.yml
+++ b/staging/ControllerContainerBlockHostPath/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerContainerBlockPortsRange/questions-ui.yml
+++ b/staging/ControllerContainerBlockPortsRange/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerContainerEnforceEnvVar/questions-ui.yml
+++ b/staging/ControllerContainerEnforceEnvVar/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerContainerProhibitEnvVar/questions-ui.yml
+++ b/staging/ControllerContainerProhibitEnvVar/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerContainerRunningPrivilegedMode/questions-ui.yml
+++ b/staging/ControllerContainerRunningPrivilegedMode/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerContainerServiceAccountTokenAutomount/questions-ui.yml
+++ b/staging/ControllerContainerServiceAccountTokenAutomount/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerContainerUsingHostPort/questions-ui.yml
+++ b/staging/ControllerContainerUsingHostPort/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerDockerSocketMount/questions-ui.yml
+++ b/staging/ControllerDockerSocketMount/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerImageApprovedRegistry/questions-ui.yml
+++ b/staging/ControllerImageApprovedRegistry/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerImagePullPolicy/questions-ui.yml
+++ b/staging/ControllerImagePullPolicy/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerImageTag/questions-ui.yml
+++ b/staging/ControllerImageTag/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerMinimumReplicaCount/questions-ui.yml
+++ b/staging/ControllerMinimumReplicaCount/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerMissingMatchLabelKey/questions-ui.yml
+++ b/staging/ControllerMissingMatchLabelKey/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerProbesCustom/questions-ui.yml
+++ b/staging/ControllerProbesCustom/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerProbesNamedPort/questions-ui.yml
+++ b/staging/ControllerProbesNamedPort/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerReadOnlyFileSystem/questions-ui.yml
+++ b/staging/ControllerReadOnlyFileSystem/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerResourcesMaxCPULimits/questions-ui.yml
+++ b/staging/ControllerResourcesMaxCPULimits/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerResourcesMaxCPURequests/questions-ui.yml
+++ b/staging/ControllerResourcesMaxCPURequests/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerResourcesMaxMemoryLimits/questions-ui.yml
+++ b/staging/ControllerResourcesMaxMemoryLimits/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerResourcesMaxMemoryRequests/questions-ui.yml
+++ b/staging/ControllerResourcesMaxMemoryRequests/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerResourcesMinCPULimits/questions-ui.yml
+++ b/staging/ControllerResourcesMinCPULimits/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerResourcesMinCPURequests/questions-ui.yml
+++ b/staging/ControllerResourcesMinCPURequests/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerResourcesMinMemoryLimits/questions-ui.yml
+++ b/staging/ControllerResourcesMinMemoryLimits/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerResourcesMinMemoryRequests/questions-ui.yml
+++ b/staging/ControllerResourcesMinMemoryRequests/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerRestartPolicy/questions-ui.yml
+++ b/staging/ControllerRestartPolicy/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerSeccompRuntimeDefault/questions-ui.yml
+++ b/staging/ControllerSeccompRuntimeDefault/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerShareHostIPC/questions-ui.yml
+++ b/staging/ControllerShareHostIPC/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerShareHostNetwork/questions-ui.yml
+++ b/staging/ControllerShareHostNetwork/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerShareHostPID/questions-ui.yml
+++ b/staging/ControllerShareHostPID/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerShareProcessNamespace/questions-ui.yml
+++ b/staging/ControllerShareProcessNamespace/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerSpecGeneric/questions-ui.yml
+++ b/staging/ControllerSpecGeneric/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerSpecTemplateLabels/questions-ui.yml
+++ b/staging/ControllerSpecTemplateLabels/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ControllerTolerations/questions-ui.yml
+++ b/staging/ControllerTolerations/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/IngressClass/questions-ui.yml
+++ b/staging/IngressClass/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/IngressHostname/questions-ui.yml
+++ b/staging/IngressHostname/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/KubernetesKubeletVersion/questions-ui.yml
+++ b/staging/KubernetesKubeletVersion/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/KubernetesProhibitKind/questions-ui.yml
+++ b/staging/KubernetesProhibitKind/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/NamespaceProhibitName/questions-ui.yml
+++ b/staging/NamespaceProhibitName/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/NetworkPolicyAllowEgressAllFromNamespace/questions-ui.yml
+++ b/staging/NetworkPolicyAllowEgressAllFromNamespace/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/NetworkPolicyAllowEgressAllFromNamespaceToCIDR/questions-ui.yml
+++ b/staging/NetworkPolicyAllowEgressAllFromNamespaceToCIDR/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/NetworkPolicyAllowEgressDNSFromNamespace/questions-ui.yml
+++ b/staging/NetworkPolicyAllowEgressDNSFromNamespace/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/NetworkPolicyAllowIngressAllToNamespace/questions-ui.yml
+++ b/staging/NetworkPolicyAllowIngressAllToNamespace/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/NetworkPolicyAllowIngressAllToNamespaceFromCIDR/questions-ui.yml
+++ b/staging/NetworkPolicyAllowIngressAllToNamespaceFromCIDR/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/NetworkPolicyBlockEgressAllFromNamespace/questions-ui.yml
+++ b/staging/NetworkPolicyBlockEgressAllFromNamespace/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/NetworkPolicyBlockEgressAllFromNamespaceToCIDR/questions-ui.yml
+++ b/staging/NetworkPolicyBlockEgressAllFromNamespaceToCIDR/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/NetworkPolicyBlockIngressAllToNamespace/questions-ui.yml
+++ b/staging/NetworkPolicyBlockIngressAllToNamespace/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/NodeCustomLabel/questions-ui.yml
+++ b/staging/NodeCustomLabel/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/NodeMissingLabel/questions-ui.yml
+++ b/staging/NodeMissingLabel/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/NodeOSVersion/questions-ui.yml
+++ b/staging/NodeOSVersion/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/PersistentVolumeClaimMaxSize/questions-ui.yml
+++ b/staging/PersistentVolumeClaimMaxSize/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/PersistentVolumeMaxSize/questions-ui.yml
+++ b/staging/PersistentVolumeMaxSize/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/PersistentVolumeReclaimPolicy/questions-ui.yml
+++ b/staging/PersistentVolumeReclaimPolicy/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/PrometheusAnnotationKey/questions-ui.yml
+++ b/staging/PrometheusAnnotationKey/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/PrometheusAnnotationValue/questions-ui.yml
+++ b/staging/PrometheusAnnotationValue/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/PrometheusRBACClusterRole/questions-ui.yml
+++ b/staging/PrometheusRBACClusterRole/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/PrometheusRBACClusterRoleBinding/questions-ui.yml
+++ b/staging/PrometheusRBACClusterRoleBinding/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/PrometheusServiceAnnontationKey/questions-ui.yml
+++ b/staging/PrometheusServiceAnnontationKey/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/RBACClusterRoleClusterAdmin/questions-ui.yml
+++ b/staging/RBACClusterRoleClusterAdmin/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/RBACProhibitEditingConfigMaps/questions-ui.yml
+++ b/staging/RBACProhibitEditingConfigMaps/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/RBACProhibitVerbsOnResources/questions-ui.yml
+++ b/staging/RBACProhibitVerbsOnResources/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/RBACProhibitWildcards/questions-ui.yml
+++ b/staging/RBACProhibitWildcards/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ServiceAccountDisableTokenAutomount/questions-ui.yml
+++ b/staging/ServiceAccountDisableTokenAutomount/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ServiceProhibitPortsRange/questions-ui.yml
+++ b/staging/ServiceProhibitPortsRange/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ServiceProhibitType/questions-ui.yml
+++ b/staging/ServiceProhibitType/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+

--- a/staging/ServiceRestrictProtocols/questions-ui.yml
+++ b/staging/ServiceRestrictProtocols/questions-ui.yml
@@ -1,0 +1,13 @@
+questions:
+- default: value
+  description: >-
+    This policy has required settings, but corresponding UI elements are not yet implemented.
+    Please configure the settings manually via the Edit YAML tab.
+    Additional information is available in the policy's README file.
+  group: Settings
+  label: Description
+  required: false
+  hide_input: true
+  type: string
+  variable: name
+


### PR DESCRIPTION
Some policies define required parameters in policy.yaml.

For those policies add template with message about required settings. This will display Settings tab in the UI.

To find policies with required settings I used:
```bash
cd rego-policies-library
grep -r 'required: true' -m1 */*/policy.yaml | grep -Eo '(policies|staging)/[^/]+' | sort -u | xargs -I{} cp ./questions-ui.yml {}/
```

![Screenshot from 2025-04-14 14-39-25](https://github.com/user-attachments/assets/1b17e2f0-4f76-4ce4-919e-8f10b44f32fb)

