### PR TITLE
Generate UI questions from policy parameters

### DIFF
--- a/policies/ControllerAffinityNodeSelector/questions-ui.yml
+++ b/policies/ControllerAffinityNodeSelector/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: key
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Key
+  - variable: value
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Value

--- a/policies/ControllerContainerBlockSSHPort/questions-ui.yml
+++ b/policies/ControllerContainerBlockSSHPort/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: container_port
+    default: 22
+    required: true
+    group: Settings
+    type: integer
+    label: Container port

--- a/policies/ControllerContainerRunningAsUser/questions-ui.yml
+++ b/policies/ControllerContainerRunningAsUser/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: uid
+    default: 0
+    required: true
+    group: Settings
+    type: integer
+    label: Uid

--- a/policies/ControllerImageName/questions-ui.yml
+++ b/policies/ControllerImageName/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: restricted_image_names
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Restricted image names

--- a/policies/ControllerMissingLabelValue/questions-ui.yml
+++ b/policies/ControllerMissingLabelValue/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: label
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Label
+  - variable: value
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Value

--- a/policies/ControllerProhibitNamespace/questions-ui.yml
+++ b/policies/ControllerProhibitNamespace/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: custom_namespace
+    default: default
+    required: true
+    group: Settings
+    type: string
+    label: Custom namespace

--- a/policies/FluxBucketApprovedRegion/questions-ui.yml
+++ b/policies/FluxBucketApprovedRegion/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: regions
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Regions

--- a/policies/FluxBucketEndpointDomain/questions-ui.yml
+++ b/policies/FluxBucketEndpointDomain/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: domains
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Domains

--- a/policies/FluxGitRepositoryIgonreSuffixes/questions-ui.yml
+++ b/policies/FluxGitRepositoryIgonreSuffixes/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: suffixes
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Suffixes

--- a/policies/FluxGitRepositoryOrganizationDomains/questions-ui.yml
+++ b/policies/FluxGitRepositoryOrganizationDomains/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: domains
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Domains

--- a/policies/FluxGitRepositorySpecificBranch/questions-ui.yml
+++ b/policies/FluxGitRepositorySpecificBranch/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: branch
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Branch

--- a/policies/FluxGitRepositoryUntrustedDomains/questions-ui.yml
+++ b/policies/FluxGitRepositoryUntrustedDomains/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: untrusted_domains
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Untrusted domains

--- a/policies/FluxHelmReleaseMaxHistory/questions-ui.yml
+++ b/policies/FluxHelmReleaseMaxHistory/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: max_history
+    default: 100
+    required: true
+    group: Settings
+    type: integer
+    label: Max history

--- a/policies/FluxHelmReleaseRemediationRetries/questions-ui.yml
+++ b/policies/FluxHelmReleaseRemediationRetries/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: lower_bound
+    default: 1
+    required: true
+    group: Settings
+    type: integer
+    label: Lower bound
+  - variable: upper_bound
+    default: 10
+    required: true
+    group: Settings
+    type: integer
+    label: Upper bound

--- a/policies/FluxHelmReleaseServiceAccountName/questions-ui.yml
+++ b/policies/FluxHelmReleaseServiceAccountName/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: service_account_names
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Service account names

--- a/policies/FluxHelmReleaseStorageNamespace/questions-ui.yml
+++ b/policies/FluxHelmReleaseStorageNamespace/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: storage_namespaces
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Storage namespaces

--- a/policies/FluxHelmReleaseTargetNameSpace/questions-ui.yml
+++ b/policies/FluxHelmReleaseTargetNameSpace/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: target_namespaces
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Target namespaces

--- a/policies/FluxHelmReleaseValuesFromConfigMaps/questions-ui.yml
+++ b/policies/FluxHelmReleaseValuesFromConfigMaps/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: configmaps
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Configmaps

--- a/policies/FluxHelmRepositoryURL/questions-ui.yml
+++ b/policies/FluxHelmRepositoryURL/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: domains
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Domains

--- a/policies/FluxKustomizationDecryptionProvider/questions-ui.yml
+++ b/policies/FluxKustomizationDecryptionProvider/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: decryption_providers
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Decryption providers

--- a/policies/FluxKustomizationPaths/questions-ui.yml
+++ b/policies/FluxKustomizationPaths/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: exclude_paths
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Exclude paths

--- a/policies/FluxKustomizationTargetNamespace/questions-ui.yml
+++ b/policies/FluxKustomizationTargetNamespace/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: target_namespaces
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Target namespaces

--- a/policies/FluxKustomizeImagesRequirement/questions-ui.yml
+++ b/policies/FluxKustomizeImagesRequirement/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: images_required
+    default: true
+    required: true
+    group: Settings
+    type: boolean
+    label: Images required

--- a/policies/FluxKustomizePatchesRequirement/questions-ui.yml
+++ b/policies/FluxKustomizePatchesRequirement/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: patches_required
+    default:
+    required: true
+    group: Settings
+    type: boolean
+    label: Patches required

--- a/policies/FluxKustomizePrune/questions-ui.yml
+++ b/policies/FluxKustomizePrune/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: prune
+    default:
+    required: true
+    group: Settings
+    type: boolean
+    label: Prune

--- a/policies/FluxOCIRepositoryIgonreSuffixes/questions-ui.yml
+++ b/policies/FluxOCIRepositoryIgonreSuffixes/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: suffixes
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Suffixes

--- a/policies/FluxOCIRepositoryLayerSelector/questions-ui.yml
+++ b/policies/FluxOCIRepositoryLayerSelector/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: media_types
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Media types
+  - variable: operations
+    default: ["extract"]
+    required: true
+    group: Settings
+    type: array[
+    label: Operations

--- a/policies/FluxOCIRepositoryOrganizationDomains/questions-ui.yml
+++ b/policies/FluxOCIRepositoryOrganizationDomains/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: domains
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Domains

--- a/policies/FluxOCIRepositoryPatchAnnotation/questions-ui.yml
+++ b/policies/FluxOCIRepositoryPatchAnnotation/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: provider
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Provider

--- a/policies/FluxResourceReconcileInterval/questions-ui.yml
+++ b/policies/FluxResourceReconcileInterval/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: lower_bound
+    default: 1
+    required: true
+    group: Settings
+    type: integer
+    label: Lower bound
+  - variable: upper_bound
+    default: 1000
+    required: true
+    group: Settings
+    type: integer
+    label: Upper bound

--- a/policies/FluxResourceWaiverList/questions-ui.yml
+++ b/policies/FluxResourceWaiverList/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: waiver_list
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Waiver list

--- a/policies/IstioGatewayHosts/questions-ui.yml
+++ b/policies/IstioGatewayHosts/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: hostnames
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Hostnames

--- a/policies/IstioNamespaceLabelInjection/questions-ui.yml
+++ b/policies/IstioNamespaceLabelInjection/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: namespaces
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Namespaces

--- a/policies/NamespaceLimitRangeMinMax/questions-ui.yml
+++ b/policies/NamespaceLimitRangeMinMax/questions-ui.yml
@@ -1,13 +1,19 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: resource_type
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Resource type
+  - variable: resource_setting
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Resource setting
+  - variable: namespace
+    default: magalix
+    required: true
+    group: Settings
+    type: string
+    label: Namespace

--- a/policies/NamespacePodQuota/questions-ui.yml
+++ b/policies/NamespacePodQuota/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: pod_quota
+    default: 2
+    required: true
+    group: Settings
+    type: string
+    label: Pod quota
+  - variable: namespace
+    default: magalix
+    required: true
+    group: Settings
+    type: string
+    label: Namespace

--- a/policies/NamespaceResourceQuotas/questions-ui.yml
+++ b/policies/NamespaceResourceQuotas/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: resource_type
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Resource type
+  - variable: namespace
+    default: magalix
+    required: true
+    group: Settings
+    type: string
+    label: Namespace

--- a/policies/NetworkPolicyAllowEgressFromNamespaceToNamespace/questions-ui.yml
+++ b/policies/NetworkPolicyAllowEgressFromNamespaceToNamespace/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: src_namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Src namespace
+  - variable: dst_namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Dst namespace

--- a/policies/NetworkPolicyAllowIngressFromNamespaceToNamespace/questions-ui.yml
+++ b/policies/NetworkPolicyAllowIngressFromNamespaceToNamespace/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: src_namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Src namespace
+  - variable: dst_namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Dst namespace

--- a/policies/NetworkPolicyBlockIngressAllToNamespaceFromCIDR/questions-ui.yml
+++ b/policies/NetworkPolicyBlockIngressAllToNamespaceFromCIDR/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Namespace
+  - variable: cidr
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Cidr

--- a/policies/PersistentVolumeAccessModes/questions-ui.yml
+++ b/policies/PersistentVolumeAccessModes/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: name
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Name
+  - variable: access_mode
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Access mode

--- a/policies/PersistentVolumeClaimSnapshot/questions-ui.yml
+++ b/policies/PersistentVolumeClaimSnapshot/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: snapshot_class
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Snapshot class
+  - variable: pvc_name
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Pvc name

--- a/policies/RBACProhibitListOnSecrets/questions-ui.yml
+++ b/policies/RBACProhibitListOnSecrets/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: resource
+    default: "secrets"
+    required: true
+    group: Settings
+    type: string
+    label: Resource
+  - variable: verb
+    default: "list"
+    required: true
+    group: Settings
+    type: string
+    label: Verb

--- a/policies/RBACProhibitWatchOnSecrets/questions-ui.yml
+++ b/policies/RBACProhibitWatchOnSecrets/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: resource
+    default: "secrets"
+    required: true
+    group: Settings
+    type: string
+    label: Resource
+  - variable: verb
+    default: "watch"
+    required: true
+    group: Settings
+    type: string
+    label: Verb

--- a/policies/RBACProhibitWildcardOnSecrets/questions-ui.yml
+++ b/policies/RBACProhibitWildcardOnSecrets/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: resource
+    default: "secrets"
+    required: true
+    group: Settings
+    type: string
+    label: Resource
+  - variable: verb
+    default: "*"
+    required: true
+    group: Settings
+    type: string
+    label: Verb

--- a/policies/RBACProhibitWildcardsOnPolicyRuleResources/questions-ui.yml
+++ b/policies/RBACProhibitWildcardsOnPolicyRuleResources/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: attributes
+    default: "resources"
+    required: true
+    group: Settings
+    type: string
+    label: Attributes
+  - variable: exclude_role_name
+    default: ""
+    required: true
+    group: Settings
+    type: string
+    label: Exclude role name

--- a/policies/RBACProhibitWildcardsOnPolicyRuleVerbs/questions-ui.yml
+++ b/policies/RBACProhibitWildcardsOnPolicyRuleVerbs/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: attributes
+    default: "verbs"
+    required: true
+    group: Settings
+    type: string
+    label: Attributes
+  - variable: exclude_role_name
+    default: ""
+    required: true
+    group: Settings
+    type: string
+    label: Exclude role name

--- a/staging/ControllerAffinityNode/questions-ui.yml
+++ b/staging/ControllerAffinityNode/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: keys
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Keys

--- a/staging/ControllerAffinityPods/questions-ui.yml
+++ b/staging/ControllerAffinityPods/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: keys
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Keys

--- a/staging/ControllerAntiAffinityPods/questions-ui.yml
+++ b/staging/ControllerAntiAffinityPods/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: keys
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Keys

--- a/staging/ControllerContainerAllowingPrivilegeEscalation/questions-ui.yml
+++ b/staging/ControllerContainerAllowingPrivilegeEscalation/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: allow_privilege_escalation
+    default: false
+    required: true
+    group: Settings
+    type: boolean
+    label: Allow privilege escalation

--- a/staging/ControllerContainerBlockHostPath/questions-ui.yml
+++ b/staging/ControllerContainerBlockHostPath/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: hostpath_key
+    default: hostPath
+    required: true
+    group: Settings
+    type: string
+    label: Hostpath key

--- a/staging/ControllerContainerBlockPortsRange/questions-ui.yml
+++ b/staging/ControllerContainerBlockPortsRange/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: target_port
+    default: 1024
+    required: true
+    group: Settings
+    type: integer
+    label: Target port

--- a/staging/ControllerContainerEnforceEnvVar/questions-ui.yml
+++ b/staging/ControllerContainerEnforceEnvVar/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: envvar_name
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Envvar name
+  - variable: app_name
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: App name

--- a/staging/ControllerContainerProhibitEnvVar/questions-ui.yml
+++ b/staging/ControllerContainerProhibitEnvVar/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: envvar_name
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Envvar name
+  - variable: app_name
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: App name

--- a/staging/ControllerContainerRunningPrivilegedMode/questions-ui.yml
+++ b/staging/ControllerContainerRunningPrivilegedMode/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: privilege
+    default: false
+    required: true
+    group: Settings
+    type: boolean
+    label: Privilege

--- a/staging/ControllerContainerServiceAccountTokenAutomount/questions-ui.yml
+++ b/staging/ControllerContainerServiceAccountTokenAutomount/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: automount_token
+    default: false
+    required: true
+    group: Settings
+    type: boolean
+    label: Automount token

--- a/staging/ControllerContainerUsingHostPort/questions-ui.yml
+++ b/staging/ControllerContainerUsingHostPort/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: host_port
+    default: hostPort
+    required: true
+    group: Settings
+    type: string
+    label: Host port

--- a/staging/ControllerDockerSocketMount/questions-ui.yml
+++ b/staging/ControllerDockerSocketMount/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: docker_sock
+    default: docker.sock
+    required: true
+    group: Settings
+    type: string
+    label: Docker sock

--- a/staging/ControllerImageApprovedRegistry/questions-ui.yml
+++ b/staging/ControllerImageApprovedRegistry/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: registries
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Registries

--- a/staging/ControllerImagePullPolicy/questions-ui.yml
+++ b/staging/ControllerImagePullPolicy/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: policy
+    default: Always
+    required: true
+    group: Settings
+    type: string
+    label: Policy

--- a/staging/ControllerImageTag/questions-ui.yml
+++ b/staging/ControllerImageTag/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: image_tag
+    default: latest
+    required: true
+    group: Settings
+    type: string
+    label: Image tag

--- a/staging/ControllerMinimumReplicaCount/questions-ui.yml
+++ b/staging/ControllerMinimumReplicaCount/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: replica_count
+    default: 2
+    required: true
+    group: Settings
+    type: integer
+    label: Replica count

--- a/staging/ControllerMissingMatchLabelKey/questions-ui.yml
+++ b/staging/ControllerMissingMatchLabelKey/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: label
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Label

--- a/staging/ControllerProbesCustom/questions-ui.yml
+++ b/staging/ControllerProbesCustom/questions-ui.yml
@@ -1,13 +1,25 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: probe_type
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Probe type
+  - variable: command
+    default:
+    required: false
+    group: Settings
+    type: array[
+    label: Command
+  - variable: path
+    default:
+    required: false
+    group: Settings
+    type: string
+    label: Path
+  - variable: port
+    default:
+    required: false
+    group: Settings
+    type: integer
+    label: Port

--- a/staging/ControllerProbesNamedPort/questions-ui.yml
+++ b/staging/ControllerProbesNamedPort/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: probe
+    default: livenessProbe
+    required: true
+    group: Settings
+    type: string
+    label: Probe

--- a/staging/ControllerReadOnlyFileSystem/questions-ui.yml
+++ b/staging/ControllerReadOnlyFileSystem/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: read_only
+    default: true
+    required: true
+    group: Settings
+    type: boolean
+    label: Read only

--- a/staging/ControllerResourcesMaxCPULimits/questions-ui.yml
+++ b/staging/ControllerResourcesMaxCPULimits/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: size
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Size

--- a/staging/ControllerResourcesMaxCPURequests/questions-ui.yml
+++ b/staging/ControllerResourcesMaxCPURequests/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: size
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Size

--- a/staging/ControllerResourcesMaxMemoryLimits/questions-ui.yml
+++ b/staging/ControllerResourcesMaxMemoryLimits/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: size
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Size

--- a/staging/ControllerResourcesMaxMemoryRequests/questions-ui.yml
+++ b/staging/ControllerResourcesMaxMemoryRequests/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: size
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Size

--- a/staging/ControllerResourcesMinCPULimits/questions-ui.yml
+++ b/staging/ControllerResourcesMinCPULimits/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: size
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Size

--- a/staging/ControllerResourcesMinCPURequests/questions-ui.yml
+++ b/staging/ControllerResourcesMinCPURequests/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: size
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Size

--- a/staging/ControllerResourcesMinMemoryLimits/questions-ui.yml
+++ b/staging/ControllerResourcesMinMemoryLimits/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: size
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Size

--- a/staging/ControllerResourcesMinMemoryRequests/questions-ui.yml
+++ b/staging/ControllerResourcesMinMemoryRequests/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: size
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Size

--- a/staging/ControllerRestartPolicy/questions-ui.yml
+++ b/staging/ControllerRestartPolicy/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: restart_policy
+    default: Always
+    required: true
+    group: Settings
+    type: string
+    label: Restart policy

--- a/staging/ControllerSeccompRuntimeDefault/questions-ui.yml
+++ b/staging/ControllerSeccompRuntimeDefault/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: seccomp_annotation
+    default: runtime/default
+    required: true
+    group: Settings
+    type: string
+    label: Seccomp annotation
+  - variable: seccomp_type
+    default: RuntimeDefault
+    required: true
+    group: Settings
+    type: string
+    label: Seccomp type

--- a/staging/ControllerShareHostIPC/questions-ui.yml
+++ b/staging/ControllerShareHostIPC/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: resource_enabled
+    default: false
+    required: true
+    group: Settings
+    type: boolean
+    label: Resource enabled

--- a/staging/ControllerShareHostNetwork/questions-ui.yml
+++ b/staging/ControllerShareHostNetwork/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: resource_enabled
+    default: false
+    required: true
+    group: Settings
+    type: boolean
+    label: Resource enabled

--- a/staging/ControllerShareHostPID/questions-ui.yml
+++ b/staging/ControllerShareHostPID/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: resource_enabled
+    default: false
+    required: true
+    group: Settings
+    type: boolean
+    label: Resource enabled

--- a/staging/ControllerShareProcessNamespace/questions-ui.yml
+++ b/staging/ControllerShareProcessNamespace/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: resource_enabled
+    default: false
+    required: true
+    group: Settings
+    type: boolean
+    label: Resource enabled

--- a/staging/ControllerSpecGeneric/questions-ui.yml
+++ b/staging/ControllerSpecGeneric/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: controller_spec_key
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Controller spec key

--- a/staging/ControllerSpecTemplateLabels/questions-ui.yml
+++ b/staging/ControllerSpecTemplateLabels/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: label
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Label

--- a/staging/ControllerTolerations/questions-ui.yml
+++ b/staging/ControllerTolerations/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: toleration_key
+    default: node-role.kubernetes.io/master
+    required: true
+    group: Settings
+    type: string
+    label: Toleration key

--- a/staging/IngressClass/questions-ui.yml
+++ b/staging/IngressClass/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: class
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Class
+  - variable: annotation
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Annotation

--- a/staging/IngressHostname/questions-ui.yml
+++ b/staging/IngressHostname/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: hostnames
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Hostnames

--- a/staging/KubernetesKubeletVersion/questions-ui.yml
+++ b/staging/KubernetesKubeletVersion/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: version
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Version

--- a/staging/KubernetesProhibitKind/questions-ui.yml
+++ b/staging/KubernetesProhibitKind/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: kind
+    default: Pods
+    required: true
+    group: Settings
+    type: string
+    label: Kind

--- a/staging/NamespaceProhibitName/questions-ui.yml
+++ b/staging/NamespaceProhibitName/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: namespace_name
+    default: kube-
+    required: true
+    group: Settings
+    type: string
+    label: Namespace name

--- a/staging/NetworkPolicyAllowEgressAllFromNamespace/questions-ui.yml
+++ b/staging/NetworkPolicyAllowEgressAllFromNamespace/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Namespace

--- a/staging/NetworkPolicyAllowEgressAllFromNamespaceToCIDR/questions-ui.yml
+++ b/staging/NetworkPolicyAllowEgressAllFromNamespaceToCIDR/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Namespace
+  - variable: cidr
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Cidr

--- a/staging/NetworkPolicyAllowEgressDNSFromNamespace/questions-ui.yml
+++ b/staging/NetworkPolicyAllowEgressDNSFromNamespace/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Namespace

--- a/staging/NetworkPolicyAllowIngressAllToNamespace/questions-ui.yml
+++ b/staging/NetworkPolicyAllowIngressAllToNamespace/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Namespace

--- a/staging/NetworkPolicyAllowIngressAllToNamespaceFromCIDR/questions-ui.yml
+++ b/staging/NetworkPolicyAllowIngressAllToNamespaceFromCIDR/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Namespace
+  - variable: cidr
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Cidr

--- a/staging/NetworkPolicyBlockEgressAllFromNamespace/questions-ui.yml
+++ b/staging/NetworkPolicyBlockEgressAllFromNamespace/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Namespace

--- a/staging/NetworkPolicyBlockEgressAllFromNamespaceToCIDR/questions-ui.yml
+++ b/staging/NetworkPolicyBlockEgressAllFromNamespaceToCIDR/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Namespace
+  - variable: cidr
+    default:
+    required: true
+    group: Settings
+    type: array[
+    label: Cidr

--- a/staging/NetworkPolicyBlockIngressAllToNamespace/questions-ui.yml
+++ b/staging/NetworkPolicyBlockIngressAllToNamespace/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Namespace

--- a/staging/NodeCustomLabel/questions-ui.yml
+++ b/staging/NodeCustomLabel/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: key
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Key
+  - variable: value
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Value

--- a/staging/NodeMissingLabel/questions-ui.yml
+++ b/staging/NodeMissingLabel/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: node_label
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Node label

--- a/staging/NodeOSVersion/questions-ui.yml
+++ b/staging/NodeOSVersion/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: os
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Os

--- a/staging/PersistentVolumeClaimMaxSize/questions-ui.yml
+++ b/staging/PersistentVolumeClaimMaxSize/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: size
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Size

--- a/staging/PersistentVolumeMaxSize/questions-ui.yml
+++ b/staging/PersistentVolumeMaxSize/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: size
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Size

--- a/staging/PersistentVolumeReclaimPolicy/questions-ui.yml
+++ b/staging/PersistentVolumeReclaimPolicy/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: pv_policy
+    default: Retain
+    required: true
+    group: Settings
+    type: string
+    label: Pv policy

--- a/staging/PrometheusAnnotationKey/questions-ui.yml
+++ b/staging/PrometheusAnnotationKey/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: prometheus_annotation_key
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Prometheus annotation key

--- a/staging/PrometheusAnnotationValue/questions-ui.yml
+++ b/staging/PrometheusAnnotationValue/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: prometheus_annotation_key
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Prometheus annotation key
+  - variable: prometheus_annotation_value
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Prometheus annotation value

--- a/staging/PrometheusRBACClusterRole/questions-ui.yml
+++ b/staging/PrometheusRBACClusterRole/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: prometheus_verb
+    default: put
+    required: true
+    group: Settings
+    type: string
+    label: Prometheus verb

--- a/staging/PrometheusRBACClusterRoleBinding/questions-ui.yml
+++ b/staging/PrometheusRBACClusterRoleBinding/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: prometheus_subject_name
+    default: prometheus
+    required: true
+    group: Settings
+    type: string
+    label: Prometheus subject name

--- a/staging/PrometheusServiceAnnontationKey/questions-ui.yml
+++ b/staging/PrometheusServiceAnnontationKey/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: prometheus_service_annotation
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Prometheus service annotation

--- a/staging/RBACClusterRoleClusterAdmin/questions-ui.yml
+++ b/staging/RBACClusterRoleClusterAdmin/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: subjects_name
+    default: system:masters
+    required: true
+    group: Settings
+    type: string
+    label: Subjects name
+  - variable: subjects_kind
+    default: Group
+    required: true
+    group: Settings
+    type: string
+    label: Subjects kind

--- a/staging/RBACProhibitEditingConfigMaps/questions-ui.yml
+++ b/staging/RBACProhibitEditingConfigMaps/questions-ui.yml
@@ -1,13 +1,19 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: resource_name
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Resource name
+  - variable: verb
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Verb
+  - variable: namespace
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Namespace

--- a/staging/RBACProhibitVerbsOnResources/questions-ui.yml
+++ b/staging/RBACProhibitVerbsOnResources/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: resource
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Resource
+  - variable: verb
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Verb

--- a/staging/RBACProhibitWildcards/questions-ui.yml
+++ b/staging/RBACProhibitWildcards/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: attributes
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Attributes
+  - variable: exclude_role_name
+    default:
+    required: true
+    group: Settings
+    type: string
+    label: Exclude role name

--- a/staging/ServiceAccountDisableTokenAutomount/questions-ui.yml
+++ b/staging/ServiceAccountDisableTokenAutomount/questions-ui.yml
@@ -1,13 +1,13 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: automount
+    default: false
+    required: true
+    group: Settings
+    type: boolean
+    label: Automount
+  - variable: namespace
+    default: default
+    required: true
+    group: Settings
+    type: string
+    label: Namespace

--- a/staging/ServiceProhibitPortsRange/questions-ui.yml
+++ b/staging/ServiceProhibitPortsRange/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: target_port
+    default: 1024
+    required: true
+    group: Settings
+    type: integer
+    label: Target port

--- a/staging/ServiceProhibitType/questions-ui.yml
+++ b/staging/ServiceProhibitType/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: type
+    default: NodePort
+    required: true
+    group: Settings
+    type: string
+    label: Type

--- a/staging/ServiceRestrictProtocols/questions-ui.yml
+++ b/staging/ServiceRestrictProtocols/questions-ui.yml
@@ -1,13 +1,7 @@
 questions:
-- default: value
-  description: >-
-    This policy has required settings, but corresponding UI elements are not yet implemented.
-    Please configure the settings manually via the Edit YAML tab.
-    Additional information is available in the policy's README file.
-  group: Settings
-  label: Description
-  required: false
-  hide_input: true
-  type: string
-  variable: name
-
+  - variable: protocols
+    default: HTTPS
+    required: true
+    group: Settings
+    type: string
+    label: Protocols


### PR DESCRIPTION
## Description

Policies have 4 types: `array`, `string`, `integer`, `string`. Those types we support in kubewarden UI.
We don't have field descriptions or labels, initial conversion is quite minimal.

Almost all rego policies include following exclude settings:
- exclude_namespaces
- exclude_label_key
- exclude_label_value

I removed them since we have `namespaceSelector` and `matchConditions` in kubewarden, this seems duplicit.
Exclude parameters are still available, just not from questions.


```fish
# Generation script for reference
for d in */*/; yq '
   {"questions": [.spec.parameters[] | select(.name != "exclude_namespaces" and .name != "exclude_label_key" and .name != "exclude_label_value") | {
     "variable": .name,
     "default": .value,
     "required": .required,
     "group": "Settings",
     "type": (.type | sub("^array$", "array[")),
     "label": (.name | sub("_", " "))
   }]}
 ' $d/policy.yaml \
 | sed -E "s/label: (.)/label: \u\1/" \
 | sed '/^questions: \[]/d' > $d/questions-ui.yml; end
 
 find . -type f -name questions-ui.yml -empty -delete
```