### PR TITLE
fix(FluxKustomizationTargetNamespace): validate missing namespace

### DIFF
--- a/policies/FluxKustomizationTargetNamespace/metadata.yml
+++ b/policies/FluxKustomizationTargetNamespace/metadata.yml
@@ -11,7 +11,7 @@ annotations:
   io.artifacthub.keywords: flux
   io.artifacthub.resources: Kustomization
   io.kubewarden.policy.title: kustomization-target-namespace
-  io.kubewarden.policy.version: 1.0.3
+  io.kubewarden.policy.version: 1.0.4
   io.kubewarden.policy.description: "Kustomization targetNamespace must be one of the allowed targetNamespace list."
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/kustomization-target-namespace

--- a/policies/FluxKustomizationTargetNamespace/policy.rego
+++ b/policies/FluxKustomizationTargetNamespace/policy.rego
@@ -10,18 +10,30 @@ exclude_namespaces := input.parameters.exclude_namespaces
 exclude_label_key := input.parameters.exclude_label_key
 exclude_label_value := input.parameters.exclude_label_value
 target_namespaces := input.parameters.target_namespaces
+target_namespace_list := concat(", ", target_namespaces)
+
+violation[result] {
+    isExcludedNamespace == false
+    not exclude_label_value == kustomization_input.metadata.labels[exclude_label_key]
+    not kustomization_input.spec.targetNamespace
+    result = {
+        "issue_detected": true,
+        "msg": sprintf("The Kustomization '%s' targetNamespace must be one of the allowed target namespaces: %v; found none", [kustomization_input.metadata.name, target_namespace_list]),
+        "violating_key": "spec.targetNamespace"
+    }
+}
 
 violation[result] {
     isExcludedNamespace == false
     not exclude_label_value == kustomization_input.metadata.labels[exclude_label_key]
     not kustomization_input.spec.targetNamespace in target_namespaces
-    target_namespace_list := concat(", ", target_namespaces)
     result = {
         "issue_detected": true,
         "msg": sprintf("The Kustomization '%s' targetNamespace must be one of the allowed target namespaces: %v; found '%s'", [kustomization_input.metadata.name, target_namespace_list, kustomization_input.spec.targetNamespace]),
         "violating_key": "spec.targetNamespace"
     }
 }
+
 
 # Kustomization input
 kustomization_input = input.review.object {

--- a/policies/FluxKustomizationTargetNamespace/tests/policy_test.rego
+++ b/policies/FluxKustomizationTargetNamespace/tests/policy_test.rego
@@ -50,6 +50,29 @@ test_invalid_target_namespace {
   count(violation) == 1 with input as testcase
 }
 
+test_missing_target_namespace {
+  testcase = {
+    "parameters": {
+      "exclude_namespaces": [],
+      "exclude_label_key": "",
+      "exclude_label_value": "",
+      "target_namespaces": ["allowed-namespace"]
+    },
+    "review": {
+      "object": {
+        "kind": "Kustomization",
+        "metadata": {
+          "name": "invalid-kustomization",
+        },
+        "spec": {
+        }
+      }
+    }
+  }
+
+  count(violation) == 1 with input as testcase
+}
+
 test_exclude_label_target_namespace {
   testcase = {
     "parameters": {


### PR DESCRIPTION
## Description

Updates the policy to ensure that resources missing the optional targetNamespace field will be rejected by the policy.

Fix https://github.com/kubewarden/rego-policies-library/issues/50



## Test


```shell
make test
```

