### PR TITLE
fix(ControllerContainerRunningAsRoot): detect missing securityContext

### DIFF
--- a/policies/ControllerContainerRunningAsRoot/README.md
+++ b/policies/ControllerContainerRunningAsRoot/README.md
@@ -11,6 +11,15 @@ You should set `securityContext.runAsNonRoot` to `true`. Not setting it will def
       runAsNonRoot: true
 ```
 
+## Policy Behavior
+
+This policy detects and flags:
+- Containers where `securityContext.runAsNonRoot` is explicitly set to `false`
+- Pods where `securityContext.runAsNonRoot` is explicitly set to `false`
+- Containers **or pods where `securityContext` is entirely omitted** (will default to running as root)
+
+Even if other `securityContext` fields like `runAsUser` are set, omitting `runAsNonRoot: true` (or omitting the entire `securityContext` block) is considered a violation.
+
 https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 
 # Settings

--- a/policies/ControllerContainerRunningAsRoot/metadata.yml
+++ b/policies/ControllerContainerRunningAsRoot/metadata.yml
@@ -19,7 +19,7 @@ annotations:
   io.artifacthub.keywords: pci-dss, cis-benchmark, mitre-attack, nist800-190, gdpr, default
   io.artifacthub.resources: Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob
   io.kubewarden.policy.title: container-running-as-root
-  io.kubewarden.policy.version: 1.0.4
+  io.kubewarden.policy.version: 1.0.5
   io.kubewarden.policy.description: "Running as root gives the container full access to all resources in the VM it is running on. Containers should not run with such access rights unless required by design. This Policy enforces that the `securityContext.runAsNonRoot` attribute is set to `true`. \n"
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/container-running-as-root

--- a/policies/ControllerContainerRunningAsRoot/policy.rego
+++ b/policies/ControllerContainerRunningAsRoot/policy.rego
@@ -15,13 +15,11 @@ violation[result] {
 	isExcludedNamespace == false
 	not exclude_label_value == controller_input.metadata.labels[exclude_label_key]
 
-	controller_spec.securityContext
 	not controller_spec.securityContext.runAsNonRoot
 	not controller_spec.securityContext.runAsNonRoot == false
 
 	some i
 	containers := controller_spec.containers[i]
-	containers.securityContext
 	not containers.securityContext.runAsNonRoot
 	not containers.securityContext.runAsNonRoot == false
 

--- a/policies/ControllerContainerRunningAsRoot/policy.yaml
+++ b/policies/ControllerContainerRunningAsRoot/policy.yaml
@@ -58,13 +58,11 @@ spec:
     	isExcludedNamespace == false
     	not exclude_label_value == controller_input.metadata.labels[exclude_label_key]
 
-    	controller_spec.securityContext
     	not controller_spec.securityContext.runAsNonRoot
     	not controller_spec.securityContext.runAsNonRoot == false
 
     	some i
     	containers := controller_spec.containers[i]
-    	containers.securityContext
     	not containers.securityContext.runAsNonRoot
     	not containers.securityContext.runAsNonRoot == false
 

--- a/policies/ControllerContainerRunningAsRoot/tests/container_missing_securityContext_pod_incomplete_test.rego
+++ b/policies/ControllerContainerRunningAsRoot/tests/container_missing_securityContext_pod_incomplete_test.rego
@@ -1,0 +1,40 @@
+package policy
+
+test_container_missing_securityContext_pod_incomplete {
+  testcase = {
+    "parameters": {
+      "exclude_namespaces": [],
+      "exclude_label_key": "",
+      "exclude_label_value": "",
+    },
+    "review": {
+      "object": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "name": "security-context-demo",
+        },
+        "spec": {
+          "securityContext" : {
+            "runAsUser": 1000,
+          },
+          "containers": [
+            {
+              "name": "sec-ctx-demo",
+              "image": "busybox",
+              "command": [
+                "sh",
+                "-c",
+                "sleep 1h"
+              ],
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  # container omits securityContext entirely, pod-level securityContext is
+  # present but does not set runAsNonRoot -> still a violation
+  count(violation) == 1 with input as testcase
+}

--- a/policies/ControllerContainerRunningAsRoot/tests/missing_securityContext_cronjob_test.rego
+++ b/policies/ControllerContainerRunningAsRoot/tests/missing_securityContext_cronjob_test.rego
@@ -1,0 +1,45 @@
+package policy
+
+test_missing_securityContext_cronjob {
+  testcase = {
+    "parameters": {
+      "exclude_namespaces": [],
+      "exclude_label_key": "",
+      "exclude_label_value": "",
+    },
+    "review": {
+      "object": {
+        "apiVersion": "batch/v1",
+        "kind": "CronJob",
+        "metadata": {
+          "name": "no-security-context-demo",
+        },
+        "spec": {
+          "jobTemplate": {
+            "spec": {
+              "template": {
+                "spec": {
+                  "containers": [
+                    {
+                      "name": "sec-ctx-demo",
+                      "image": "busybox",
+                      "command": [
+                        "sh",
+                        "-c",
+                        "sleep 1h"
+                      ],
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # CronJob traversal path (spec.jobTemplate.spec.template.spec), both
+  # pod-level and container-level securityContext entirely omitted
+  count(violation) == 1 with input as testcase
+}

--- a/policies/ControllerContainerRunningAsRoot/tests/missing_securityContext_mixed_containers_test.rego
+++ b/policies/ControllerContainerRunningAsRoot/tests/missing_securityContext_mixed_containers_test.rego
@@ -1,0 +1,50 @@
+package policy
+
+test_missing_securityContext_mixed_containers {
+  testcase = {
+    "parameters": {
+      "exclude_namespaces": [],
+      "exclude_label_key": "",
+      "exclude_label_value": "",
+    },
+    "review": {
+      "object": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "name": "security-context-demo",
+        },
+        "spec": {
+          "containers": [
+            {
+              "name": "sec-ctx-demo-missing",
+              "image": "busybox",
+              "command": [
+                "sh",
+                "-c",
+                "sleep 1h"
+              ],
+            },
+            {
+              "securityContext" : {
+                "runAsNonRoot": true,
+              },
+              "name": "sec-ctx-demo-ok",
+              "image": "busybox",
+              "command": [
+                "sh",
+                "-c",
+                "sleep 1h"
+              ],
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  # pod-level securityContext is entirely absent; one container omits
+  # securityContext entirely (violation), the sibling container explicitly
+  # sets runAsNonRoot: true (no violation) -> only 1 violation total
+  count(violation) == 1 with input as testcase
+}

--- a/policies/ControllerContainerRunningAsRoot/tests/missing_securityContext_test.rego
+++ b/policies/ControllerContainerRunningAsRoot/tests/missing_securityContext_test.rego
@@ -1,0 +1,83 @@
+package policy
+
+test_missing_securityContext_pod {
+  testcase = {
+    "parameters": {
+      "exclude_namespaces": [],
+      "exclude_label_key": "",
+      "exclude_label_value": "",
+    },
+    "review": {
+      "object": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "name": "no-security-context-demo",
+        },
+        "spec": {
+          "containers": [
+            {
+              "name": "sec-ctx-demo",
+              "image": "busybox",
+              "command": [
+                "sh",
+                "-c",
+                "sleep 1h"
+              ],
+            },
+            {
+              "name": "sec-ctx-demo2",
+              "image": "busybox",
+              "command": [
+                "sh",
+                "-c",
+                "sleep 1h"
+              ],
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  # 1 violation per container, no securityContext defined anywhere
+  count(violation) == 2 with input as testcase
+}
+
+test_missing_securityContext_deployment {
+  testcase = {
+    "parameters": {
+      "exclude_namespaces": [],
+      "exclude_label_key": "",
+      "exclude_label_value": "",
+    },
+    "review": {
+      "object": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "no-security-context-demo",
+        },
+        "spec": {
+          "template": {
+            "spec": {
+              "containers": [
+                {
+                  "name": "sec-ctx-demo",
+                  "image": "busybox",
+                  "command": [
+                    "sh",
+                    "-c",
+                    "sleep 1h"
+                  ],
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+
+  count(violation) == 1 with input as testcase
+}

--- a/policies/ControllerContainerRunningAsRoot/tests/pod_missing_securityContext_container_runAsNonRoot_true_test.rego
+++ b/policies/ControllerContainerRunningAsRoot/tests/pod_missing_securityContext_container_runAsNonRoot_true_test.rego
@@ -1,0 +1,40 @@
+package policy
+
+test_pod_missing_securityContext_container_runAsNonRoot_true {
+  testcase = {
+    "parameters": {
+      "exclude_namespaces": [],
+      "exclude_label_key": "",
+      "exclude_label_value": "",
+    },
+    "review": {
+      "object": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "name": "security-context-demo",
+        },
+        "spec": {
+          "containers": [
+            {
+              "securityContext" : {
+                "runAsNonRoot": true,
+              },
+              "name": "sec-ctx-demo",
+              "image": "busybox",
+              "command": [
+                "sh",
+                "-c",
+                "sleep 1h"
+              ],
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  # pod-level securityContext is entirely absent, but the container
+  # explicitly sets runAsNonRoot: true -> no violation
+  count(violation) == 0 with input as testcase
+}


### PR DESCRIPTION
The "missing runAsNonRoot" violation rule required the securityContext object itself to be present at both pod and container level before checking for a missing runAsNonRoot field. This meant containers/pods that omitted securityContext entirely (rather than defining it without runAsNonRoot) were never flagged, even though they default to running as root.

Once merged, we should tag a new version of this policy.
